### PR TITLE
Make :sanitation => false actually not sanitize

### DIFF
--- a/lib/best_in_place.rb
+++ b/lib/best_in_place.rb
@@ -31,7 +31,7 @@ module BestInPlace
       out << " data-inner-class='#{opts[:inner_class].to_s}'" if opts[:inner_class]
       if !opts[:sanitize].nil? && !opts[:sanitize]
         out << " data-sanitize='false'>"
-        out << sanitize(value.to_s, :tags => %w(b i u s a strong em p h1 h2 h3 h4 h5 ul li ol hr pre span img br), :attributes => %w(id class href))
+        out << value.to_s
       else
         out << ">#{sanitize(value.to_s, :tags => nil, :attributes => nil)}"
       end


### PR DESCRIPTION
By default, :sanitation => false only changes what elements what elements are allowed, not whether or not sanitation is performed.

This pull request fixes that.
