### PR TITLE
Added possibility to load raw data before editing (usefull for textiled texts).

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -22,6 +22,7 @@ module BestInPlace
       out = "<span class='best_in_place'"
       out << " id='best_in_place_#{object.class.to_s.gsub("::", "_").underscore}_#{field}'"
       out << " data-url='#{opts[:path].blank? ? url_for(object).to_s : url_for(opts[:path])}'"
+      out << " data-load-url='#{opts[:load_path]}'" unless opts[:load_path].blank?
       out << " data-object='#{object.class.to_s.gsub("::", "_").underscore}'"
       out << " data-collection='#{collection}'" unless collection.blank?
       out << " data-attribute='#{field}'"
@@ -49,4 +50,3 @@ module BestInPlace
     end
   end
 end
-


### PR DESCRIPTION
Please consider including this update to master. Those updates implement loading of raw data to allow usage of markup (such as textile) in editing mode. 

Changes:
- added 'load_path' hash key for options of best_in_place's helper to specify URL for loading raw data;
- added loading of data by specified URL (in JS)
- added loading of data returned within response: so after update server sends updated data to browser for displaying (in case with textile it returns rendered html as response)
