### PR TITLE
Allow for tabbing through best_in_place fields

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -24,7 +24,7 @@ function BestInPlaceEditor(e) {
   this.initOptions();
   this.bindForm();
   this.initNil();
-  $(this.activator).bind('click', {editor: this}, this.clickHandler);
+  $(this.activator).bind('focus', {editor: this}, this.clickHandler);
 }
 
 BestInPlaceEditor.prototype = {
@@ -33,14 +33,14 @@ BestInPlaceEditor.prototype = {
   activate : function() {
     var elem = this.isNil ? "" : this.element.html();
     this.oldValue = elem;
-    $(this.activator).unbind("click", this.clickHandler);
+    $(this.activator).unbind("focus", this.clickHandler);
     this.activateForm();
   },
 
   abort : function() {
     if (this.isNil) this.element.html(this.nil);
     else            this.element.html(this.oldValue);
-    $(this.activator).bind('click', {editor: this}, this.clickHandler);
+    $(this.activator).bind('focus', {editor: this}, this.clickHandler);
   },
 
   update : function() {
@@ -181,7 +181,7 @@ BestInPlaceEditor.prototype = {
     this.element.trigger($.Event("ajax:success"), data);
 
     // Binding back after being clicked
-    $(this.activator).bind('click', {editor: this}, this.clickHandler);
+    $(this.activator).bind('focus', {editor: this}, this.clickHandler);
   },
 
   loadErrorCallback : function(request, error) {
@@ -195,7 +195,7 @@ BestInPlaceEditor.prototype = {
     });
 
     // Binding back after being clicked
-    $(this.activator).bind('click', {editor: this}, this.clickHandler);
+    $(this.activator).bind('focus', {editor: this}, this.clickHandler);
   },
 
   clickHandler : function(event) {

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -20,7 +20,7 @@ module BestInPlace
         value = fieldValue ? opts[:collection][1] : opts[:collection][0]
         collection = opts[:collection].to_json
       end
-      out = "<span class='best_in_place'"
+      out = "<span class='best_in_place' tabindex='0'"
       out << " id='#{BestInPlace::Utils.build_best_in_place_id(object, field)}'"
       out << " data-url='#{opts[:path].blank? ? url_for(object).to_s : url_for(opts[:path])}'"
       out << " data-object='#{object.class.to_s.gsub("::", "_").underscore}'"


### PR DESCRIPTION
fields created with the best_in_place helper can now be selected by
tabbing through all elements on a page. Going back using shift+tab
seems to be broken, needs more investigating.
