### PR TITLE
replace apostrophes in collection with corresponding HTML entity

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -24,7 +24,7 @@ module BestInPlace
       out << " id='#{BestInPlace::Utils.build_best_in_place_id(object, field)}'"
       out << " data-url='#{opts[:path].blank? ? url_for(object).to_s : url_for(opts[:path])}'"
       out << " data-object='#{object.class.to_s.gsub("::", "_").underscore}'"
-      out << " data-collection='#{collection}'" unless collection.blank?
+      out << " data-collection='#{collection.gsub(/'/, "&#39;")}'" unless collection.blank?
       out << " data-attribute='#{field}'"
       out << " data-activator='#{opts[:activator]}'" unless opts[:activator].blank?
       out << " data-nil='#{opts[:nil].to_s}'" unless opts[:nil].blank?

--- a/spec/helpers/best_in_place_spec.rb
+++ b/spec/helpers/best_in_place_spec.rb
@@ -199,6 +199,18 @@ describe BestInPlace::BestInPlaceHelpers do
       it "should show the current country" do
         @span.text.should == "Italy"
       end
+
+      context "with an apostrophe in it" do
+        before do
+          @apostrophe_countries = [[1, "Joe's Country"], [2, "Bob's Country"]]
+          nk = Nokogiri::HTML.parse(helper.best_in_place @user, :country, :type => :select, :collection => @apostrophe_countries)
+          @span = nk.css("span")
+        end
+
+        it "should have a proper data collection" do
+          @span.attribute("data-collection").value.should == @apostrophe_countries.to_json
+        end
+      end
     end
   end
 


### PR DESCRIPTION
```
best_in_place @user, :country, :type => :select, :collection => [[1, "O'Hara'"], [2, "O'Douls"]]
```

Currently, best_in_place chokes on collections with apostrophes in their values, because they get rendered down like this:

```
data-collection='[[1, "O'Hara'"], [2, "O'Douls"]]'
```

The data-collection attribute is then `[[1, "O`, and best_in_place is going to have a hard time turning that back into a string. "SyntaxError: JSON Parse error: Unterminated string"

This pull request includes:

1) A failing test case for this scenario

2) A quick fix which instead causes our data-collection to render (correctly) as:

```
data-collection='[[1, "O&#39;Hara'"], [2, "O&#39;Douls"]]'
```

This is then parsed correctly by the browser to create the expected select values ("O'Hara, O'Douls").
