### PR TITLE
Replace $ with jQuery for compatibility

### DIFF
--- a/lib/best_in_place/version.rb
+++ b/lib/best_in_place/version.rb
@@ -1,3 +1,3 @@
 module BestInPlace
-  VERSION = "1.0.7"
+  VERSION = "1.0.6"
 end


### PR DESCRIPTION
I was running into trouble trying to use best_in_place on an old app that needs to be running Prototype for compatibility reasons. This change replaces instances of $ with jQuery, because $ is can be assigned to Prototype.
