### PR TITLE
Add support for mongoid in the select option by using v.id as a key to the hash

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -20,6 +20,7 @@ module BestInPlace
       if opts[:type] == :select && !opts[:collection].blank?
         v = object.send(field)
         value = Hash[opts[:collection]][!!(v =~ /^[0-9]+$/) ? v.to_i : v]
+        value = Hash[opts[:collection]][v.id] if value.nil?
         collection = opts[:collection].to_json
       end
       if opts[:type] == :checkbox


### PR DESCRIPTION
using mongoid, the Hash key to the collection doesn't seem to work. 
My patch fixes that by using the object's id (if the value wasn't previously found).

// I wasn't able to make run the specs (they all failed...). sorry...
