### PR TITLE
Allow :display_with to accept a proc

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -6,7 +6,7 @@ module BestInPlace
         raise ArgumentError, "Can't use both 'display_as' and 'display_with' options at the same time"
       end
 
-      if opts[:display_with] && !ViewHelpers.respond_to?(opts[:display_with])
+      if opts[:display_with] && !opts[:display_with].is_a?(Proc) && !ViewHelpers.respond_to?(opts[:display_with])
         raise ArgumentError, "Can't find helper #{opts[:display_with]}"
       end
 
@@ -67,6 +67,9 @@ module BestInPlace
       if opts[:display_as]
         BestInPlace::DisplayMethods.add_model_method(object.class.to_s, field, opts[:display_as])
         object.send(opts[:display_as]).to_s
+
+      elsif opts[:display_with].try(:is_a?, Proc)
+        opts[:display_with].call(object.send(field))
 
       elsif opts[:display_with]
         BestInPlace::DisplayMethods.add_helper_method(object.class.to_s, field, opts[:display_with], opts[:helper_options])

--- a/spec/helpers/best_in_place_spec.rb
+++ b/spec/helpers/best_in_place_spec.rb
@@ -179,6 +179,13 @@ describe BestInPlace::BestInPlaceHelpers do
           span.text.should == "$150.00"
         end
 
+        it "accepts a proc" do
+          out = helper.best_in_place @user, :name, :display_with => Proc.new { |v| v.upcase }
+          nk = Nokogiri::HTML.parse(out)
+          span = nk.css("span")
+          span.text.should == "LUCIA"
+        end
+
         it "should raise an error if the given helper can't be found" do
           lambda { helper.best_in_place @user, :money, :display_with => :fk_number_to_currency }.should raise_error(ArgumentError)
         end


### PR DESCRIPTION
This was added to allow calling `html_safe` on `textilize` so HTML entities weren't escaped, ie:

```
:display_with => lambda { |v| textilize(v).html_safe }
```

Added a spec but didn't update README.
