### PR TITLE
Show nil text when original value is blank

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -64,6 +64,8 @@ module BestInPlace
 
   private
     def build_value_for(object, field, opts)
+      return "" if object.send(field).blank?
+
       if opts[:display_as]
         BestInPlace::DisplayMethods.add_model_method(object.class.to_s, field, opts[:display_as])
         object.send(opts[:display_as]).to_s

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -465,6 +465,15 @@ describe "JS behaviour", :js => true do
   end
 
   describe "display_with" do
+    it "should show nil text when original value is nil" do
+      @user.description = ""
+      @user.save!
+
+      visit user_path(@user)
+
+      within("#dw_description") { page.should have_content("-") }
+    end
+
     it "should render the money using number_to_currency" do
       @user.save!
       visit user_path(@user)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,9 @@ RSpec.configure do |config|
 
   # == Mock Framework
   config.mock_with :rspec
+
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
 end
 
 Capybara.default_wait_time = 5


### PR DESCRIPTION
For example:

```
best_in_place @user, :name,
  :display_with => :simple_format, :nil => "Fill me"
```

When the user name is nil then the output is `<p></p>` instead of Fill me.
