### PR TITLE
Escape new lines

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -85,7 +85,12 @@ module BestInPlace
     end
 
     def attribute_escape(data)
-      data.to_s.gsub("&", "&amp;").gsub("'", "&apos;") unless data.nil?
+      return unless data
+
+      data.to_s.
+        gsub("&", "&amp;").
+        gsub("'", "&apos;").
+        gsub("\n", "&#10;")
     end
   end
 end


### PR DESCRIPTION
Some browsers screw up the text area view when new lines are not escaped
properly.

Sorry for not providing a spec for it. I wasn't able to write a good test.
