### PR TITLE
Add trigger 'ajax:error' for error response.

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -224,7 +224,8 @@ BestInPlaceEditor.prototype = {
       var container = $("<span class='flash-error'></span>").html(value);
       container.purr();
     });
-
+    this.element.trigger($.Event("ajax:error"));
+    
     // Binding back after being clicked
     $(this.activator).bind('click', {editor: this}, this.clickHandler);
   },


### PR DESCRIPTION
Hi! I found useful to have a trigger when the request was not successful.
There was already one for successful responses, but it is also useful to have one in error responses.
