### PR TITLE
preventDefault in clickHandler

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -232,6 +232,7 @@ BestInPlaceEditor.prototype = {
   },
 
   clickHandler : function(event) {
+    event.preventDefault();
     event.data.editor.activate();
   },
 


### PR DESCRIPTION
Prevent default in clickHandler to stop scrolling window to top when activator is <a href="#">
