### PR TITLE
add activate and deactivate events

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -46,6 +46,7 @@ BestInPlaceEditor.prototype = {
     this.oldValue = elem;
     this.display_value = to_display;
     $(this.activator).unbind("click", this.clickHandler);
+    this.element.trigger($.Event("best_in_place:activate"));
     this.activateForm();
   },
 
@@ -54,6 +55,7 @@ BestInPlaceEditor.prototype = {
     else            this.element.html(this.oldValue);
     $(this.activator).bind('click', {editor: this}, this.clickHandler);
     this.element.trigger($.Event("best_in_place:abort"));
+    this.element.trigger($.Event("best_in_place:deactivate"));
   },
 
   abortIfConfirm : function () {
@@ -214,6 +216,7 @@ BestInPlaceEditor.prototype = {
 
     // Binding back after being clicked
     $(this.activator).bind('click', {editor: this}, this.clickHandler);
+    this.element.trigger($.Event("best_in_place:deactivate"));
   },
 
   loadErrorCallback : function(request, error) {
@@ -229,6 +232,7 @@ BestInPlaceEditor.prototype = {
     
     // Binding back after being clicked
     $(this.activator).bind('click', {editor: this}, this.clickHandler);
+    this.element.trigger($.Event("best_in_place:deactivate"));
   },
 
   clickHandler : function(event) {


### PR DESCRIPTION
To allow custom callbacks when editing starts and ends (example: hide and show again the activator element)
