### PR TITLE
Bugfix: wrong param-key was generated for namespaced ActiveRecord-models

### DIFF
--- a/lib/best_in_place/controller_extensions.rb
+++ b/lib/best_in_place/controller_extensions.rb
@@ -7,7 +7,8 @@ module BestInPlace
   private
     def respond_bip_ok(obj)
       klass = obj.class.to_s
-      updating_attr = params[klass.underscore].keys.first
+      param_key = ActiveModel::Naming.param_key(obj.class)
+      updating_attr = params[param_key].keys.first
 
       if renderer = BestInPlace::DisplayMethods.lookup(klass, updating_attr)
         render :json => renderer.render_json(obj)


### PR DESCRIPTION
Example: `Animal::Herd` => `animal/herd` instead of `animal_herd`

Use `ActiveModel::Naming.param_key`, just like `#form_for`. See [form_helper.rb](https://github.com/rails/rails/blob/47cbfbb98a2a4ccb6d434998183f24be4e2bb1c1/actionpack/lib/action_view/helpers/form_helper.rb#L412)

No tests.
