### PR TITLE
bug fix when update return an error and initial string is '-'

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -42,7 +42,7 @@ BestInPlaceEditor.prototype = {
       to_display = this.element.html();
     }
 
-    var elem = this.isNil ? "" : this.element.html();
+    var elem = this.isNil ? "-" : this.element.html();
     this.oldValue = elem;
     this.display_value = to_display;
     jQuery(this.activator).unbind("click", this.clickHandler);

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -41,6 +41,18 @@ describe "JS behaviour", :js => true do
       end
     end
 
+    it "should render the default '-' string when there is an error and if the intial string is '-'" do
+      @user.money = nil
+      @user.save!
+      visit user_path(@user)
+
+      bip_text @user, :money, "abcd"
+
+      within("#money") do
+        page.should have_content("-")
+      end
+    end
+
     it "should render the passed nil value if the field is empty" do
       @user.last_name = ""
       @user.save :validate => false


### PR DESCRIPTION
This fixes an error in the case where there is validation with the "allow: blank" option, the initial string is '-' and the validation does not pass. In this case, the text field disappears and doesn't return.
