### PR TITLE
Trigger activate event after form was created

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -46,8 +46,8 @@ BestInPlaceEditor.prototype = {
     this.oldValue = elem;
     this.display_value = to_display;
     jQuery(this.activator).unbind("click", this.clickHandler);
-    this.element.trigger(jQuery.Event("best_in_place:activate"));
     this.activateForm();
+    this.element.trigger(jQuery.Event("best_in_place:activate"));
   },
 
   abort : function() {


### PR DESCRIPTION
Right now `best_in_place:activate` event is triggered when inline edit is activated but just before form is created. Sometimes it is useful to operate on form field just after it was activated, so event should be triggered later.
