### PR TITLE
A single js efficiency improvement, some != to !== and == to === changes, and a few missing ;

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -88,7 +88,7 @@ BestInPlaceEditor.prototype = {
     } else if (this.formType == "checkbox") {
       editor.element.html(this.getValue() ? this.values[1] : this.values[0]);
     } else {
-      editor.element.html(this.getValue() != "" ? this.getValue() : this.nil);
+      editor.element.html(this.getValue() !== "" ? this.getValue() : this.nil);
     }
     editor.element.trigger(jQuery.Event("best_in_place:update"));
   },
@@ -256,15 +256,15 @@ BestInPlaceEditor.forms = {
     activateForm : function() {
       var output = '<form class="form_in_place" action="javascript:void(0)" style="display:inline;">';
       output += '<input type="text" name="'+ this.attributeName + '" value="' + this.sanitizeValue(this.display_value) + '"';
-      if (this.inner_class != null) {
+      if (this.inner_class !== null) {
         output += ' class="' + this.inner_class + '"';
       }
       output += '>';
       if (this.okButton) {
-        output += '<input type="submit" value="' + this.okButton + '" />'
+        output += '<input type="submit" value="' + this.okButton + '" />';
       }
       if (this.cancelButton) {
-        output += '<input type="button" value="' + this.cancelButton + '" />'
+        output += '<input type="button" value="' + this.cancelButton + '" />';
       }
       output += '</form>';
       this.element.html(output);
@@ -272,7 +272,7 @@ BestInPlaceEditor.forms = {
       this.element.find("input[type='text']")[0].select();
       this.element.find("form").bind('submit', {editor: this}, BestInPlaceEditor.forms.input.submitHandler);
       if (this.cancelButton) {
-        this.element.find("input[type='button']").bind('click', {editor: this}, BestInPlaceEditor.forms.input.cancelButtonHandler)
+        this.element.find("input[type='button']").bind('click', {editor: this}, BestInPlaceEditor.forms.input.cancelButtonHandler);
       }
       this.element.find("input[type='text']").bind('blur', {editor: this}, BestInPlaceEditor.forms.input.inputBlurHandler);
       this.element.find("input[type='text']").bind('keyup', {editor: this}, BestInPlaceEditor.forms.input.keyupHandler);
@@ -330,10 +330,10 @@ BestInPlaceEditor.forms = {
       var that = this,
         output = '<form class="form_in_place" action="javascript:void(0)" style="display:inline;">';
       output += '<input type="text" name="'+ this.attributeName + '" value="' + this.sanitizeValue(this.display_value) + '"';
-      if (this.inner_class != null) {
+      if (this.inner_class !== null) {
         output += ' class="' + this.inner_class + '"';
       }
-      output += '></form>'
+      output += '></form>';
       this.element.html(output);
       this.setHtmlAttributes();
       this.element.find('input')[0].select();


### PR DESCRIPTION
When checking for parent supplied info, use a variable to store jQuery(this) so the jQuery wrapper isn't invoked and the DOM searched for every attribute.

Besides that, a few missing semicolons added, and a few == changed to === for more proper equality testing (though obviously no one has run into trouble so far.)
