### PR TITLE
Improved CRLF detection/escaping

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -101,7 +101,7 @@ module BestInPlace
       data.to_s.
         gsub("&", "&amp;").
         gsub("'", "&apos;").
-        gsub("\n", "&#10;")
+        gsub(/\r?\n/, "&#10;")
     end
 
     def real_object_for(object)


### PR DESCRIPTION
The existing CRLF detection in the `attribute_escape` method only detected `\n` characters. There are many instances where newlines include a carriage return (i.e. `\r\n`). When these are not escaped properly it results in double spacing in the `textarea` that is generated by best_in_place.

I have modified the regular expression to ensure that these situations are escaped.

I tried to write a useful test for this, but was unable to write anything useful.
