### PR TITLE
Added nil handler to loadErrorCallback

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -221,6 +221,7 @@ BestInPlaceEditor.prototype = {
   },
 
   loadErrorCallback : function(request, error) {
+    if (this.isNil) this.element.html(this.nil);
     this.element.html(this.oldValue);
 
     // Display all error messages from server side validation


### PR DESCRIPTION
Noticed this error today. If value was nil previously, and submits to an error, it may reset to "-" due to oldValue being nil. With this patch, the form will again display the :nil attribute.
