### PR TITLE
Added inner_class option to select fields w/ specs

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -371,7 +371,11 @@ BestInPlaceEditor.forms = {
 
   "select" : {
     activateForm : function() {
-      var output = "<form action='javascript:void(0)' style='display:inline;'><select>";
+      var output = "<form action='javascript:void(0)' style='display:inline;'><select";
+      if (this.inner_class !== null) {
+        output += ' class="' + this.inner_class + '"';
+      }
+      output += '>';
       var selected = "";
       var oldValue = this.oldValue;
       jQuery.each(this.values, function(index, value) {

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -134,6 +134,14 @@ describe "JS behaviour", :js => true do
       page.should have_content("France")
     end
   end
+  
+  it "should apply the inner_class option to a select field" do
+    @user.save!
+    visit user_path(@user)
+
+    find('#country span').click
+    find('#country').should have_css('select.some_class')
+  end
 
   it "should be able to use bip_text to change a date field" do
     @user.save!

--- a/test_app/app/views/users/show.html.erb
+++ b/test_app/app/views/users/show.html.erb
@@ -43,7 +43,7 @@
     <tr>
       <td>Country</td>
       <td id="country">
-        <%= best_in_place @user, :country, :type => :select, :collection => @countries %>
+        <%= best_in_place @user, :country, :type => :select, :collection => @countries, :inner_class => :some_class %>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
Currently, the inner_class option isn't being applied to select fields. I wanted to add it so that I could set the width of the field. I had to add the inner_class option to the test_app show page because I didn't know a better way to test it.
