### PR TITLE
Don't JS escape 'display_as' responses when :sanitize => false

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -222,10 +222,16 @@ BestInPlaceEditor.prototype = {
 
   loadSuccessCallback : function(data) {
     var response = jQuery.parseJSON(jQuery.trim(data));
+
     if (response !== null && response.hasOwnProperty("display_as")) {
       this.element.attr("data-original-content", this.element.text());
       this.original_content = this.element.text();
-      this.element.text(response["display_as"]);
+
+      if (this.element.data('sanitize') === false) {
+        this.element.html(response["display_as"]);
+      } else {
+        this.element.text(response["display_as"]);
+      }
     }
     this.element.trigger(jQuery.Event("ajax:success"), data);
 


### PR DESCRIPTION
The jQuery.fn.text() method will automatically escape all text when
inserting. This meant that text generated by :display_as and
:display_with options was being escaped when the user edited a field
causing the user to see raw HTML content until they refreshed the page.

Example:

```
  <%= best_in_place post, :content, type: :textarea,
    ok_button: 'Save', cancel_button: 'Cancel', sanitize: false,
    display_with: lambda { |v| markdown(v) } %>
```

Would show escaped HTML content to the user when they edit the field and save.
