### PR TITLE
Using ajax:error with event arguments.

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -246,8 +246,8 @@ BestInPlaceEditor.prototype = {
   loadErrorCallback : function(request, error) {
     this.element.html(this.oldValue);
 
-    this.element.trigger(jQuery.Event("best_in_place:error"), [request, error])
-    this.element.trigger(jQuery.Event("ajax:error"));
+    this.element.trigger(jQuery.Event("best_in_place:error"), [request, error]);
+    this.element.trigger(jQuery.Event("ajax:error"), request, error);
 
     // Binding back after being clicked
     jQuery(this.activator).bind('click', {editor: this}, this.clickHandler);


### PR DESCRIPTION
After writing this I realized I could have used best_in_place:error, but using ajax:error seems appropriate without having to create a new event name.
