### PR TITLE
Don't overwrite jQuery.elastic when it's already defined

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -595,6 +595,8 @@ jQuery.fn.best_in_place = function() {
 */
 
 (function(jQuery){
+  if (typeof jQuery.fn.elastic !== 'undefined') return;
+
   jQuery.fn.extend({
     elastic: function() {
       //  We will create a div clone of the textarea


### PR DESCRIPTION
This change allows users to have their own implementation of jQuery.elastic plugin. The bundled version is slightly outdated. Also, I needed to make some changes to jQuery.elastic for my own purposes and it is easier when best_in_place does not overwrite my own version.
