### PR TITLE
Depend of railties instead of rails

### DIFF
--- a/best_in_place.gemspec
+++ b/best_in_place.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "rails", "~> 3.1"
+  s.add_dependency "railties", "~> 3.1"
   s.add_dependency "jquery-rails"
 
   s.add_development_dependency "rspec-rails", "~> 2.8.0"


### PR DESCRIPTION
The rails dependency is not needed. Only railties is needed.

This gems not depend of ActiveRecord or ActiveRessource, dependencies of rails, but not of railties.
