### PR TITLE
making events triggered on success consistent with those triggered on error

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -231,6 +231,7 @@ BestInPlaceEditor.prototype = {
       this.original_content = this.element.text();
       this.element.html(response["display_as"]);
     }
+    this.element.trigger(jQuery.Event("best_in_place:success"), data);
     this.element.trigger(jQuery.Event("ajax:success"), data);
 
     // Binding back after being clicked


### PR DESCRIPTION
On error, best_in_place:error is triggered, however on success only ajax:success gets triggered, which makes it difficult to perform a specific action when a value is changed through best_in_place as opposed to just any ajax call.

This adds a trigger for best_in_place:success on success right alongside the triggered ajax:success event, which makes success/error both trigger a best_in_place event as well as an ajax event.
