### PR TITLE
Made sure best in place always use nil value

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -32,7 +32,7 @@ BestInPlaceEditor.prototype = {
 
   activate : function() {
     var to_display = "";
-    if (this.isNil) {
+    if (this.isNil()) {
       to_display = "";
     }
     else if (this.original_content) {
@@ -46,8 +46,7 @@ BestInPlaceEditor.prototype = {
       }
     }
 
-    var elem = this.isNil ? "-" : this.element.html();
-    this.oldValue = elem;
+    this.oldValue = this.isNil() ? "" : this.element.html();
     this.display_value = to_display;
     jQuery(this.activator).unbind("click", this.clickHandler);
     this.activateForm();
@@ -55,8 +54,7 @@ BestInPlaceEditor.prototype = {
   },
 
   abort : function() {
-    if (this.isNil) this.element.html(this.nil);
-    else            this.element.html(this.oldValue);
+    this.activateText(this.oldValue);
     jQuery(this.activator).bind('click', {editor: this}, this.clickHandler);
     this.element.trigger(jQuery.Event("best_in_place:abort"));
     this.element.trigger(jQuery.Event("best_in_place:deactivate"));
@@ -80,7 +78,6 @@ BestInPlaceEditor.prototype = {
       this.abort();
       return true;
     }
-    this.isNil = false;
     editor.ajax({
       "type"       : "post",
       "dataType"   : "text",
@@ -112,6 +109,11 @@ BestInPlaceEditor.prototype = {
 
   activateForm : function() {
     alert("The form was not properly initialized. activateForm is unbound");
+  },
+
+  activateText : function(value){
+    this.element.html(value);
+    if(this.isNil()) this.element.html(this.nil);
   },
 
   // Helper Functions ////////////////////////////////////////////////////////
@@ -187,9 +189,14 @@ BestInPlaceEditor.prototype = {
   initNil: function() {
     if (this.element.html() === "")
     {
-      this.isNil = true;
       this.element.html(this.nil);
     }
+  },
+
+  isNil: function() {
+    // TODO: It only work when form is deactivated. 
+    //       Condition will fail when form is activated
+    return this.element.html() === "" || this.element.html() === this.nil;
   },
 
   getValue : function() {
@@ -249,7 +256,7 @@ BestInPlaceEditor.prototype = {
   },
 
   loadErrorCallback : function(request, error) {
-    this.element.html(this.oldValue);
+    this.activateText(this.oldValue);
 
     this.element.trigger(jQuery.Event("best_in_place:error"), [request, error]);
     this.element.trigger(jQuery.Event("ajax:error"), request, error);


### PR DESCRIPTION
I found that if I set nil to other value like this :nil => "N/A", the first time I activated the input field, value in the input field will show as empty string. But the second time I activated input field, the value will show as "N/A". I think the correct behavior should be still show as empty string like the first time we activate input field.

Also, when I read the code, I found that in activate function, it still use "-" to set old value when this.isNil == true, and it create some strange behavior when there is an error raise from server side.
