### PR TITLE
Allow custom classes on OK and Cancel buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Options:
   If not defined it will show *"-"*.
 - **:activator**: Is the DOM object that can activate the field. If not defined the user will making editable by clicking on it.
 - **:ok_button**: (Inputs and textareas only) If set to a string, then an OK button will be shown with the string as its label, replacing save on blur.
+- **:ok_button_class**: (Inputs and textareas only) Specifies any extra classes to set on the OK button.
 - **:cancel_button**: (Inputs and textareas only) If set to a string, then a Cancel button will be shown with the string as its label.
+- **:cancel_button_class**: (Inputs and textareas only) Specifies any extra classes to set on the Cancel button.
 - **:sanitize**: True by default. If set to false the input/textarea will accept html tags.
 - **:html_attrs**: Hash of html arguments, such as maxlength, default-value etc.
 - **:inner_class**: Class that is set to the rendered form.

--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -121,19 +121,21 @@ BestInPlaceEditor.prototype = {
     var self = this;
     self.element.parents().each(function(){
       $parent = jQuery(this);
-      self.url           = self.url           || $parent.attr("data-url");
-      self.collection    = self.collection    || $parent.attr("data-collection");
-      self.formType      = self.formType      || $parent.attr("data-type");
-      self.objectName    = self.objectName    || $parent.attr("data-object");
-      self.attributeName = self.attributeName || $parent.attr("data-attribute");
-      self.activator     = self.activator     || $parent.attr("data-activator");
-      self.okButton      = self.okButton      || $parent.attr("data-ok-button");
-      self.cancelButton  = self.cancelButton  || $parent.attr("data-cancel-button");
-      self.nil           = self.nil           || $parent.attr("data-nil");
-      self.inner_class   = self.inner_class   || $parent.attr("data-inner-class");
-      self.html_attrs    = self.html_attrs    || $parent.attr("data-html-attrs");
-      self.original_content    = self.original_content    || $parent.attr("data-original-content");
-      self.collectionValue = self.collectionValue || $parent.attr("data-value");
+      self.url               = self.url               || $parent.attr("data-url");
+      self.collection        = self.collection        || $parent.attr("data-collection");
+      self.formType          = self.formType          || $parent.attr("data-type");
+      self.objectName        = self.objectName        || $parent.attr("data-object");
+      self.attributeName     = self.attributeName     || $parent.attr("data-attribute");
+      self.activator         = self.activator         || $parent.attr("data-activator");
+      self.okButton          = self.okButton          || $parent.attr("data-ok-button");
+      self.okButtonClass     = self.okButtonClass     || $parent.attr("data-ok-button-class");
+      self.cancelButton      = self.cancelButton      || $parent.attr("data-cancel-button");
+      self.cancelButtonClass = self.cancelButtonClass || $parent.attr("data-cancel-button-class");
+      self.nil               = self.nil               || $parent.attr("data-nil");
+      self.inner_class       = self.inner_class       || $parent.attr("data-inner-class");
+      self.html_attrs        = self.html_attrs        || $parent.attr("data-html-attrs");
+      self.original_content  = self.original_content  || $parent.attr("data-original-content");
+      self.collectionValue   = self.collectionValue   || $parent.attr("data-value");
     });
 
     // Try Rails-id based if parents did not explicitly supply something
@@ -145,19 +147,21 @@ BestInPlaceEditor.prototype = {
     });
 
     // Load own attributes (overrides all others)
-    self.url           = self.element.attr("data-url")           || self.url      || document.location.pathname;
-    self.collection    = self.element.attr("data-collection")    || self.collection;
-    self.formType      = self.element.attr("data-type")          || self.formtype || "input";
-    self.objectName    = self.element.attr("data-object")        || self.objectName;
-    self.attributeName = self.element.attr("data-attribute")     || self.attributeName;
-    self.activator     = self.element.attr("data-activator")     || self.element;
-    self.okButton      = self.element.attr("data-ok-button")     || self.okButton;
-    self.cancelButton  = self.element.attr("data-cancel-button") || self.cancelButton;
-    self.nil           = self.element.attr("data-nil")           || self.nil      || "-";
-    self.inner_class   = self.element.attr("data-inner-class")   || self.inner_class   || null;
-    self.html_attrs    = self.element.attr("data-html-attrs")    || self.html_attrs;
-    self.original_content    = self.element.attr("data-original-content") || self.original_content;
-    self.collectionValue     = self.element.attr("data-value")            || self.collectionValue;
+    self.url               = self.element.attr("data-url")                 || self.url      || document.location.pathname;
+    self.collection        = self.element.attr("data-collection")          || self.collection;
+    self.formType          = self.element.attr("data-type")                || self.formtype || "input";
+    self.objectName        = self.element.attr("data-object")              || self.objectName;
+    self.attributeName     = self.element.attr("data-attribute")           || self.attributeName;
+    self.activator         = self.element.attr("data-activator")           || self.element;
+    self.okButton          = self.element.attr("data-ok-button")           || self.okButton;
+    self.okButtonClass     = self.element.attr("data-ok-button-class")     || self.okButtonClass || "";
+    self.cancelButton      = self.element.attr("data-cancel-button")       || self.cancelButton;
+    self.cancelButtonClass = self.element.attr("data-cancel-button-class") || self.cancelButtonClass || "";
+    self.nil               = self.element.attr("data-nil")                 || self.nil      || "-";
+    self.inner_class       = self.element.attr("data-inner-class")         || self.inner_class   || null;
+    self.html_attrs        = self.element.attr("data-html-attrs")          || self.html_attrs;
+    self.original_content  = self.element.attr("data-original-content")    || self.original_content;
+    self.collectionValue   = self.element.attr("data-value")               || self.collectionValue;
 
     if (!self.element.attr("data-sanitize")) {
       self.sanitize = true;
@@ -301,6 +305,7 @@ BestInPlaceEditor.forms = {
         output.append(
           jQuery(document.createElement('input'))
           .attr('type', 'submit')
+          .attr('class', this.okButtonClass)
           .attr('value', this.okButton)
         )
       }
@@ -308,6 +313,7 @@ BestInPlaceEditor.forms = {
         output.append(
           jQuery(document.createElement('input'))
           .attr('type', 'button')
+          .attr('class', this.cancelButtonClass)
           .attr('value', this.cancelButton)
         )
       }

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -47,7 +47,9 @@ module BestInPlace
       out << " data-attribute='#{field}'"
       out << " data-activator='#{opts[:activator]}'" unless opts[:activator].blank?
       out << " data-ok-button='#{opts[:ok_button]}'" unless opts[:ok_button].blank?
+      out << " data-ok-button-class='#{opts[:ok_button_class]}'" unless opts[:ok_button_class].blank?
       out << " data-cancel-button='#{opts[:cancel_button]}'" unless opts[:cancel_button].blank?
+      out << " data-cancel-button-class='#{opts[:cancel_button_class]}'" unless opts[:cancel_button_class].blank?
       out << " data-nil='#{attribute_escape(opts[:nil])}'" unless opts[:nil].blank?
       out << " data-use-confirm='#{opts[:use_confirm]}'" unless opts[:use_confirm].nil?
       out << " data-type='#{opts[:type]}'"

--- a/spec/helpers/best_in_place_spec.rb
+++ b/spec/helpers/best_in_place_spec.rb
@@ -75,8 +75,16 @@ describe BestInPlace::BestInPlaceHelpers do
         @span.attribute("data-ok-button").should be_nil
       end
 
+      it "should have no OK button class by default" do
+        @span.attribute("data-ok-button-class").should be_nil
+      end
+
       it "should have no Cancel button text by default" do
         @span.attribute("data-cancel-button").should be_nil
+      end
+
+      it "should have no Cancel button class by default" do
+        @span.attribute("data-cancel-button-class").should be_nil
       end
 
       it "should have no Use-Confirmation dialog option by default" do
@@ -158,11 +166,25 @@ describe BestInPlace::BestInPlaceHelpers do
         span.attribute("data-ok-button").value.should == "okay"
       end
 
+      it "should have the given OK button class" do
+        out = helper.best_in_place @user, :name, :ok_button => "okay", :ok_button_class => "okay-class"
+        nk = Nokogiri::HTML.parse(out)
+        span = nk.css("span")
+        span.attribute("data-ok-button-class").value.should == "okay-class"
+      end
+
       it "should have the given Cancel button text" do
         out = helper.best_in_place @user, :name, :cancel_button => "nasty"
         nk = Nokogiri::HTML.parse(out)
         span = nk.css("span")
         span.attribute("data-cancel-button").value.should == "nasty"
+      end
+
+      it "should have the given Cancel button class" do
+        out = helper.best_in_place @user, :name, :cancel_button => "nasty", :cancel_button_class => "nasty-class"
+        nk = Nokogiri::HTML.parse(out)
+        span = nk.css("span")
+        span.attribute("data-cancel-button-class").value.should == "nasty-class"
       end
 
       it "should have the given Use-Confirmation dialog option" do

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -295,6 +295,12 @@ describe "JS behaviour", :js => true do
     page.execute_script <<-JS
       $("##{id}").click();
       $("##{id} input[name='favorite_color']").val('Blue');
+    JS
+
+    page.find("##{id} input[type='submit']").value.should == 'Do it!'
+    page.should have_css("##{id} input[type='submit'].custom-submit.other-custom-submit")
+
+    page.execute_script <<-JS
       $("##{id} input[type='submit']").click();
     JS
 
@@ -316,6 +322,12 @@ describe "JS behaviour", :js => true do
     page.execute_script <<-JS
       $("##{id}").click();
       $("##{id} input[name='favorite_color']").val('Blue');
+    JS
+
+    page.find("##{id} input[type='button']").value.should == 'Nope'
+    page.should have_css("##{id} input[type='button'].custom-cancel.other-custom-cancel")
+
+    page.execute_script <<-JS
       $("##{id} input[type='button']").click();
     JS
 

--- a/test_app/app/assets/stylesheets/style.css.erb
+++ b/test_app/app/assets/stylesheets/style.css.erb
@@ -23,6 +23,14 @@ input[type=submit], input[type=button] {
 input[type=checkbox] {
   width: 1em;
 }
+.custom-submit {
+  color: white;
+  background-color: black;
+}
+.custom-cancel {
+  border: 2px solid red;
+  font-style: italic;
+}
 textarea {
   max-height:15em;
   min-width: 40em;

--- a/test_app/app/views/users/show.html.erb
+++ b/test_app/app/views/users/show.html.erb
@@ -67,7 +67,7 @@
     <tr>
       <td>Favorite color</td>
       <td id="favorite_color">
-        <%- opts = { :ok_button => 'Do it!', :cancel_button => 'Nope' } %>
+        <%- opts = { :ok_button => 'Do it!', :cancel_button => 'Nope', :ok_button_class => 'custom-submit other-custom-submit', :cancel_button_class => 'custom-cancel other-custom-cancel' } %>
         <%- opts.delete(:ok_button) if params[:suppress_ok_button] %>
         <%- opts[:nil] = "<span class='nil'>Click to add your favorite color</span>" %>
         <%= best_in_place @user, :favorite_color, opts %>


### PR DESCRIPTION
- This makes it significantly easier to use vendor styles (e.g. Twitter
  Bootstrap) on those buttons

Also fixes #207.

Would you mind bumping the gem version when this pull request is accepted?  We wanted the OK and Cancel buttons to look like the rest of our app (using Bootstrap), and we had to resort to some awful SASS hackery to achieve that.  After this feature, we should be able to just specify a 'btn' class and be on our way :)
