### PR TITLE
jQuery 1.9 fixes for vendored jQuery purr plugin

### DIFF
--- a/lib/assets/javascripts/jquery.purr.js
+++ b/lib/assets/javascripts/jquery.purr.js
@@ -62,7 +62,7 @@
 
       // If ESC is pressed remove notice
       jQuery(document).keyup(function(e) {
-        if (e.keyCode == 27) {
+        if (e.keyCode === 27) {
           removeNotice();
         }
       });
@@ -70,7 +70,7 @@
       // Add the notice to the page and keep it hidden initially
       notice.appendTo(cont).hide();
 
-      if (jQuery.browser.msie && options.usingTransparentPNG)
+      if (options.usingTransparentPNG && jQuery.browser && jQuery.browser.msie)
       {
         // IE7 and earlier can't handle the combination of opacity and transparent pngs, so if we're using transparent pngs in our
         // notice style, we'll just skip the fading in.
@@ -87,7 +87,7 @@
       {
         var topSpotInt = setInterval(function() {
           // Check to see if our notice is the first non-sticky notice in the list
-          if (notice.prevAll('.purr').length == 0)
+          if (notice.prevAll('.purr').length === 0)
           {
             // Stop checking once the condition is met
             clearInterval(topSpotInt);
@@ -105,7 +105,7 @@
     {
       // IE7 and earlier can't handle the combination of opacity and transparent pngs, so if we're using transparent pngs in our
       // notice style, we'll just skip the fading out.
-      if (jQuery.browser.msie && options.usingTransparentPNG)
+      if (options.usingTransparentPNG && jQuery.browser && jQuery.browser.msie)
       {
         notice.css({ opacity: 0 }).animate({ height: '0px'},
             {


### PR DESCRIPTION
jQuery 1.9 removed jQuery.browser, so a couple of if statements in purr can cause exceptions.

While at it, I converted a few checks to strict equality checks.
