### PR TITLE
Use em-dash instead of hyphen to represent nil

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -46,7 +46,7 @@ BestInPlaceEditor.prototype = {
       }
     }
 
-    var elem = this.isNil ? "-" : this.element.html();
+    var elem = this.isNil ? "\u2014" : this.element.html();
     this.oldValue = elem;
     this.display_value = to_display;
     jQuery(this.activator).unbind("click", this.clickHandler);
@@ -153,7 +153,7 @@ BestInPlaceEditor.prototype = {
     self.activator     = self.element.attr("data-activator")     || self.element;
     self.okButton      = self.element.attr("data-ok-button")     || self.okButton;
     self.cancelButton  = self.element.attr("data-cancel-button") || self.cancelButton;
-    self.nil           = self.element.attr("data-nil")           || self.nil      || "-";
+    self.nil           = self.element.attr("data-nil")           || self.nil      || "\u2014";
     self.inner_class   = self.element.attr("data-inner-class")   || self.inner_class   || null;
     self.html_attrs    = self.element.attr("data-html-attrs")    || self.html_attrs;
     self.original_content    = self.element.attr("data-original-content") || self.original_content;

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -34,17 +34,17 @@ describe "JS behaviour", :js => true do
   end
 
   describe "nil option" do
-    it "should render the default '-' string when the field is empty" do
+    it "should render an em-dash when the field is empty" do
       @user.name = ""
       @user.save :validate => false
       visit user_path(@user)
 
       within("#name") do
-        page.should have_content("-")
+        page.should have_content("\u2014")
       end
     end
 
-    it "should render the default '-' string when there is an error and if the intial string is '-'" do
+    it "should render the default em-dash string when there is an error and if the intial string is em-dash" do
       @user.money = nil
       @user.save!
       visit user_path(@user)
@@ -52,7 +52,7 @@ describe "JS behaviour", :js => true do
       bip_text @user, :money, "abcd"
 
       within("#money") do
-        page.should have_content("-")
+        page.should have_content("\u2014")
       end
     end
 
@@ -590,7 +590,7 @@ describe "JS behaviour", :js => true do
 
       visit user_path(@user)
 
-      within("#dw_description") { page.should have_content("-") }
+      within("#dw_description") { page.should have_content("\u2014") }
     end
 
     it "should render the money using number_to_currency" do


### PR DESCRIPTION
The wider em-dash (http://en.wikipedia.org/wiki/Dash#Em_dash) looks better than a hyphen. I also think it's more semantically correct, though I'm not an expert on punctuation. 

I updated the tests that referred to, but there are still a handful of unrelated failing tests from before (maybe #228 addresses this?).
