### PR TITLE
Only use display_as property from response when defined

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -229,7 +229,10 @@ BestInPlaceEditor.prototype = {
 
     if(data && data!=""){
       var response = jQuery.parseJSON(jQuery.trim(data));
-      if (response !== null && response.hasOwnProperty("display_as")) {
+      var attr = this.element.attr("data-original-content");
+      var customDisplayMethod = typeof attr !== 'undefined' && attr !== false;
+
+      if (customDisplayMethod && response !== null response.hasOwnProperty("display_as")) {
         this.element.attr("data-original-content", this.element.text());
         this.original_content = this.element.text();
         this.element.html(response["display_as"]);


### PR DESCRIPTION
Hey,

I am using best_in_place as follows:

``` ruby
best_in_place @issue, :summary
best_in_place @issue, :description, :display_as => :description_markdown
```

That causes a problem when the response includes a property called `display_as`. Since I am using the same path to update my property my response always includes a `display_as` property. I have added a new condition to the successHandler to only update the element with the `display_as` property when the data attribute `original-content` is set.

Please note that all the JS specs are failing after following the instructions from the README.:

```
ReferenceError: $ is not defined
```

I may need some advices on how to run the js specs. I am using Firefox 18.0.2

Thanks,
Tobias
