### PR TITLE
add options to respond_with_bip

### DIFF
--- a/lib/best_in_place/controller_extensions.rb
+++ b/lib/best_in_place/controller_extensions.rb
@@ -1,17 +1,19 @@
 module BestInPlace
   module ControllerExtensions
-    def respond_with_bip(obj)
-      obj.changed? ? respond_bip_error(obj) : respond_bip_ok(obj)
+    def respond_with_bip(obj, options={})
+      obj.changed? ? respond_bip_error(obj) : respond_bip_ok(obj, options)
     end
 
   private
-    def respond_bip_ok(obj)
-      if obj.respond_to?(:id)
+    def respond_bip_ok(obj, options)
+      if options[:class_name]
+        klass = options[:class_name]
+      elsif obj.respond_to?(:id)
         klass = "#{obj.class}_#{obj.id}"
       else
         klass = obj.class.to_s
       end
-      param_key = BestInPlace::Utils.object_to_key(obj)
+      param_key = options[:param_key] || BestInPlace::Utils.object_to_key(obj)
       updating_attr = params[param_key].keys.first
 
       if renderer = BestInPlace::DisplayMethods.lookup(klass, updating_attr)


### PR DESCRIPTION
hi, i added an optional options hash to respond_with_bip. Our app uses STI models and share a view that uses best_in_place and share a controller. The view uses :object_name and :path options to configure it, but the controller extensions dont have corresponding options. (I know its a bit unusual to share a resource controller for STI models but thats how our app does it in this case). Thanks!

example: 

```
respond_with_bip post, class_name: 'Post', param_key: 'post'
```
