### PR TITLE
Enable setting class of the ok and cancel buttons when using a textarea

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -506,6 +506,7 @@ BestInPlaceEditor.forms = {
         output.append(
           jQuery(document.createElement('input'))
           .attr('type', 'submit')
+          .attr('class', this.okButtonClass)
           .attr('value', this.okButton)
         );
       }
@@ -513,8 +514,9 @@ BestInPlaceEditor.forms = {
         output.append(
           jQuery(document.createElement('input'))
           .attr('type', 'button')
+          .attr('class', this.cancelButtonClass)
           .attr('value', this.cancelButton)
-        )
+        );
       }
 
       this.element.html(output);


### PR DESCRIPTION
Currently the :ok_button_class and :cancel_button_class options have no effect when using a textarea, only when using an input. This fixes that.
