### PR TITLE
Delay initialization of ViewHelpers in railtie

### DIFF
--- a/lib/best_in_place/railtie.rb
+++ b/lib/best_in_place/railtie.rb
@@ -1,6 +1,6 @@
 module BestInPlace
   class Railtie < Rails::Railtie
-    initializer "set view helpers" do
+    config.after_initialize do
       BestInPlace::ViewHelpers = ActionView::Base.new
     end
   end


### PR DESCRIPTION
I have a Rails app with the default_locale set to spanish. After including your gem in my project, I noticed that text in views were rendered in english. After some debugging I found that the problem was in the gem's railtie, where you create a new instance of ActionView::Base. It seems that at that point locales were not properly initialized. Using config.after_initialize, as recommended in rails guides (http://guides.rubyonrails.org/configuring.html#rails-general-configuration), solves this.
