### PR TITLE
In test_app, use \A \z for start end regex instead of ^ $

### DIFF
--- a/test_app/app/models/user.rb
+++ b/test_app/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ActiveRecord::Base
     :presence => {:message => "can't be blank"}
   validates :email,
     :presence => {:message => "can't be blank"},
-    :format => {:with => /^([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})$/i, :message => "has wrong email format"}
+    :format => {:with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, :message => "has wrong email format"}
   validates :zip, :numericality => true, :length => { :minimum => 5 }
   validates_numericality_of :money, :allow_blank => true
   validates_numericality_of :money_proc, :allow_blank => true

--- a/test_app/app/views/users/edit.html.erb
+++ b/test_app/app/views/users/edit.html.erb
@@ -1,0 +1,5 @@
+<h1>Edit user</h1>
+
+<%= render 'form' %>
+
+<%= link_to 'Back', users_path %>


### PR DESCRIPTION
This is a fix for the test_app email format validation to use the more secure match of the string start and end instead of line start and end.

The sample app was failing tests because it did not have an user#edit view
