### PR TITLE
Display the nil value on blank display_as

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -243,7 +243,12 @@ BestInPlaceEditor.prototype = {
       if (response !== null && response.hasOwnProperty("display_as")) {
         this.element.attr("data-original-content", this.element.text());
         this.original_content = this.element.text();
-        this.element.html(response["display_as"]);
+        if (response["display_as"] === "" || response["display_as"] === null) {
+          this.element.html(this.nil);
+        }
+        else {
+          this.element.html(response["display_as"]);
+        }
       }
 
       this.element.trigger(jQuery.Event("best_in_place:success"), data);


### PR DESCRIPTION
Make sure we display the configured nil string when a successful
update returns a blank (null or "") display_as field. Without this
fix fields can become unupdatable.
