### PR TITLE
Datepicker extracted to event. Jquery-ui-rails. Callback docs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gemspec
 
 gem 'sqlite3'
 gem 'jquery-rails'
+gem 'jquery-ui-rails'
 gem 'rdiscount'
 gem 'coveralls', require: false

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The editor works by PUTting the updated value to the server and GETting the upda
 - Compatible with **textarea**
 - Compatible with **select** dropdown with custom collections
 - Compatible with custom boolean values (same usage of **checkboxes**)
-- Compatible with **jQuery UI Datepickers**
+- Compatible with **jQuery UI Datepickers**, and [others through events](#datepickers)
 - Sanitize HTML and trim spaces of user's input on user's choice
 - Displays server-side **validation** errors
 - Allows external activator
@@ -184,9 +184,21 @@ You can also pass in a proc or lambda like this:
 
     = best_in_place @post, :body, :display_with => lambda { |v| textilize(v).html_safe }
 
-## Ajax success callback
+## Callbacks
 
-### Binding to ajax:success
+### Available callbacks
+
+Best in place provides the following callbacks:
+
+- **best_in_place:activate**: When the in place form is activated
+- **best_in_place:abort**: When the update is aborted (escape key, cancel button, or cancelled by popup)
+- **best_in_place:datepicker**: When a date field form is activated. Used for the jQuery datepicker. See [Datepickers](#datepickers).
+- **best_in_place:deactivate**: When the in place form is deactivated
+- **ajax:success**, **best_in_place:success**: When the ajax call has returns successfully. best_in_place:success is available if you have conflicts with ajax:success.
+- **ajax:error**, **best_in_place:error**: When the ajax call returns an error condition. best_in_place:error is available if you have conflicts with ajax:error.
+- **best_in_place:update**: Called when the form field is updated and the ajax has been started (not returned.)
+
+### Binding to ajax:success or best_in_place:success
 
 The 'ajax:success' event is triggered upon success. Use bind:
 
@@ -304,6 +316,10 @@ The parameters are defined here (some are method-specific):
 * **new_value** (only **bip_area** and **bip_text**): the new value with which to fill the BIP field.
 * **name** (only **bip_select**): the name to select from the dropdown selector.
 
+To use include them in your test config:
+
+    include BestInPlace::TestHelpers
+
 ---
 
 ##Installation
@@ -315,16 +331,23 @@ thanks to Rails 3.1. Just begin including the gem in your Gemfile:
 
     gem "best_in_place"
 
-After that, specify the use of the jquery and best in place
-javascripts in your application.js, and optionally specify jquery-ui if
-you want to use jQuery UI datepickers:
+After that, specify the use of the jquery and best in place javascripts in your application.js:
 
     //= require jquery
-    //= require jquery-ui
     //= require best_in_place
 
-If you want to use jQuery UI datepickers, you should also install and
-load your preferred jquery-ui CSS file and associated assets.
+If you want to use jQuery UI datepickers, add [jquery-ui-rails](https://github.com/joliss/jquery-ui-rails) to your Gemfile:
+
+    gem "jquery-ui-rails"
+    gem "best_in_place"
+
+and add (at least) jquery.ui.datepicker to your application.js:
+
+    //= require jquery
+    //= require jquery.ui.datepicker
+    //= require best_in_place
+
+[jquery-ui-rails](https://github.com/joliss/jquery-ui-rails) includes all CSS and associated assets, so you are done. (What happened to jquery-ui? See [Datepickers](#datepickers).)
 
 Then, just add a binding to prepare all best in place fields when the document is ready:
 
@@ -358,7 +381,7 @@ You can automatize this installation by doing
     rails g best_in_place:setup
 
 If you want to use jQuery UI datepickers, you should also install and
-load jquery-ui.js as well as your preferred jquery-ui CSS file and
+load jquery-ui.js, as well as your preferred jquery-ui CSS file and
 associated assets.
 
 Finally, as for Rails 3.1, just add a binding to prepare all best in place fields when the document is ready:
@@ -388,6 +411,35 @@ You'll have to load the following additional javascripts, in this order, after l
 
  * jquery.purr
  * **best_in_place.purr**
+
+---
+
+## Datepickers
+
+Upon activation, date fields will fire the best_in_place:datepicker event. By default the jQuery UI datepicker is enabled. If you use a different datepicker, or if you wish to specify more options, create your own event response. See the included bootstrap handler for an example.
+
+###jquery-rails 2.3.0 and below
+
+As of [jquery-rails](https://github.com/rails/jquery-rails) 3.0, jquery-ui is no longer included. If you use jquery-rails 2.3.0 and below, and you can't upgrade to 3.0, and you can't use [jquery-ui-rails](https://github.com/joliss/jquery-ui-rails), your application.js changes to
+
+    //= require jquery
+    //= require jquery-ui
+    //= require best_in_place
+
+Do not include jquery-ui-rails in your Gemfile, and then include the desired jQuery UI CSS and associated assets.
+
+###Bootstrap datepicker
+
+For a Bootstrap datepicker ([eyecon](http://www.eyecon.ro/bootstrap-datepicker/), [eternicode](https://github.com/eternicode/bootstrap-datepicker), or [bootstrap-datepicker-rails](https://github.com/Nerian/bootstrap-datepicker-rails)) add the provided best_in_place.datepicker.bootstrap to application.js:
+
+    //= require best_in_place
+    //= require best_in_place.datepicker.bootstrap
+
+###Date format###
+
+To specify a format for a given instance, add date-format to the best in place call:
+
+    <%= best_in_place @user, :birthday, :data => {:date-format => 'mm/dd/yy'} %>
 
 ---
 

--- a/best_in_place.gemspec
+++ b/best_in_place.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", ">= 3.1"
   s.add_dependency "jquery-rails"
+  s.add_dependency "jquery-ui-rails"
 
   s.add_development_dependency "rspec-rails", "~> 2.8.0"
   s.add_development_dependency "nokogiri"

--- a/lib/assets/javascripts/best_in_place.datepicker.bootstrap.js
+++ b/lib/assets/javascripts/best_in_place.datepicker.bootstrap.js
@@ -1,0 +1,17 @@
+// remove default datepicker event
+jQuery(document).off('best_in_place:datepicker');
+
+jQuery(document).on('best_in_place:datepicker', function(event, bip, element) {
+  // Display the jQuery UI datepicker popup
+  jQuery(element).find('input')
+    .datepicker({
+      format: element.data('date-format')
+    })
+    .on('hide', function(){
+        bip.update();
+    })
+    .on('changeDate', function(){
+        $(this).datepicker('hide');
+    })
+    .datepicker('show');
+});

--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -72,8 +72,9 @@ BestInPlaceEditor.prototype = {
   },
 
   update : function() {
-    var editor = this;
-    if (this.formType in {"input":1, "textarea":1} && this.getValue() == this.oldValue)
+    var editor = this,
+      new_value = this.getValue();
+    if (this.formType in {"input":1, "textarea":1, "date":1} && (new_value == this.oldValue || (new_value === '' && this.oldValue == '-')))
     { // Avoid request if no change is made
       this.abort();
       return true;
@@ -238,20 +239,16 @@ BestInPlaceEditor.prototype = {
   loadSuccessCallback : function(data) {
     data = jQuery.trim(data);
 
-    if(data && data!=""){
+    if(data && data!==""){
       var response = jQuery.parseJSON(jQuery.trim(data));
       if (response !== null && response.hasOwnProperty("display_as")) {
         this.element.attr("data-original-content", this.element.text());
         this.original_content = this.element.text();
         this.element.html(response["display_as"]);
       }
-
-      this.element.trigger(jQuery.Event("best_in_place:success"), data);
-      this.element.trigger(jQuery.Event("ajax:success"), data);
-    } else {
-      this.element.trigger(jQuery.Event("best_in_place:success"));
-      this.element.trigger(jQuery.Event("ajax:success"));
     }
+    this.element.trigger(jQuery.Event("best_in_place:success"), data);
+    this.element.trigger(jQuery.Event("ajax:success"), data);
 
     // Binding back after being clicked
     jQuery(this.activator).bind('click', {editor: this}, this.clickHandler);
@@ -267,7 +264,7 @@ BestInPlaceEditor.prototype = {
     this.activateText(this.oldValue);
 
     this.element.trigger(jQuery.Event("best_in_place:error"), [request, error]);
-    this.element.trigger(jQuery.Event("ajax:error"), request, error);
+    this.element.trigger(jQuery.Event("ajax:error"), [request, error]);
 
     // Binding back after being clicked
     jQuery(this.activator).bind('click', {editor: this}, this.clickHandler);
@@ -318,7 +315,7 @@ BestInPlaceEditor.forms = {
           .attr('type', 'submit')
           .attr('class', this.okButtonClass)
           .attr('value', this.okButton)
-        )
+        );
       }
       if(this.cancelButton) {
         output.append(
@@ -326,7 +323,7 @@ BestInPlaceEditor.forms = {
           .attr('type', 'button')
           .attr('class', this.cancelButtonClass)
           .attr('value', this.cancelButton)
-        )
+        );
       }
 
       this.element.html(output);
@@ -401,21 +398,15 @@ BestInPlaceEditor.forms = {
       if(this.inner_class !== null) {
         input_elt.addClass(this.inner_class);
       }
-      output.append(input_elt)
+      output.append(input_elt);
 
       this.element.html(output);
       this.setHtmlAttributes();
       this.element.find('input')[0].select();
       this.element.find("form").bind('submit', {editor: this}, BestInPlaceEditor.forms.input.submitHandler);
       this.element.find("input").bind('keyup', {editor: this}, BestInPlaceEditor.forms.input.keyupHandler);
-
-      this.element.find('input')
-        .datepicker({
-            onClose: function() {
-              that.update();
-            }
-          })
-        .datepicker('show');
+   
+      this.element.trigger(jQuery.Event("best_in_place:datepicker"), [that, this.element]);
     },
 
     getValue :  function() {
@@ -439,7 +430,6 @@ BestInPlaceEditor.forms = {
                        .attr('action', 'javascript:void(0)')
                        .attr('style', 'display:inline');
           selected   = '',
-          oldValue   = this.oldValue,
           select_elt = jQuery(document.createElement('select'))
                       .attr('class', this.inned_class !== null ? this.inner_class : '' ),
           currentCollectionValue = this.collectionValue;
@@ -514,7 +504,7 @@ BestInPlaceEditor.forms = {
           jQuery(document.createElement('input'))
           .attr('type', 'button')
           .attr('value', this.cancelButton)
-        )
+        );
       }
 
       this.element.html(output);
@@ -738,3 +728,16 @@ jQuery.fn.best_in_place = function() {
         }
     });
 })(jQuery);
+
+// Handle datepicker
+jQuery(document).on('best_in_place:datepicker', function(event, bip, element) {
+  // Display the jQuery UI datepicker popup
+  jQuery(element).find('input')
+    .datepicker({
+      dateFormat: element.data('date-format'),
+      onClose: function() {
+        bip.update();
+      }
+    })
+    .datepicker('show');
+});

--- a/test_app/Gemfile
+++ b/test_app/Gemfile
@@ -6,6 +6,7 @@ gem 'sqlite3'
 gem 'best_in_place', :path => ".."
 
 gem 'jquery-rails'
+gem 'jquery-ui-rails'
 
 gem 'rdiscount'
 

--- a/test_app/app/assets/javascripts/application.js
+++ b/test_app/app/assets/javascripts/application.js
@@ -1,5 +1,5 @@
 //= require jquery
-//= require jquery-ui
+//= require jquery.ui.datepicker
 //= require best_in_place
 //= require best_in_place.purr
 //= require_self


### PR DESCRIPTION
I redid this fork/pull request since the history was pretty messy. I had a lot of trouble getting git rebase to work. Now if you merge this the commit history won't be messed up.

Changes:
- Datepicker code has been extracted into an event that can be overridden for customization. An override for Bootstrap datepicker is included.
- Callbacks are listed in the README.md, and now all are tested.
- Code changed to reflect that jquery-ui is no longer included in jquery-rails. 
- Misc javascript improvements (semicolons, etc.)

All tests are passing in Rails 3. 
