### PR TITLE
:html_attrs not working for type: :date - addresses issue #293

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -280,7 +280,7 @@ BestInPlaceEditor.prototype = {
   },
 
   setHtmlAttributes : function() {
-    var formField = this.element.find(this.formType);
+    var formField = this.element.find(this.element_type);
 
     if(this.html_attrs){
       var attrs = jQuery.parseJSON(this.html_attrs);
@@ -308,6 +308,7 @@ BestInPlaceEditor.forms = {
                       .attr('type', 'text')
                       .attr('name', this.attributeName)
                       .val(this.display_value);
+      this.element_type = this.formType;
       if(this.inner_class !== null) {
         input_elt.addClass(this.inner_class);
       }
@@ -398,6 +399,7 @@ BestInPlaceEditor.forms = {
                       .attr('type', 'text')
                       .attr('name', this.attributeName)
                       .attr('value', this.sanitizeValue(this.display_value));
+      this.element_type = "input";
       if(this.inner_class !== null) {
         input_elt.addClass(this.inner_class);
       }
@@ -443,6 +445,7 @@ BestInPlaceEditor.forms = {
           select_elt = jQuery(document.createElement('select'))
                       .attr('class', this.inned_class !== null ? this.inner_class : '' ),
           currentCollectionValue = this.collectionValue;
+      this.element_type = this.formType;
 
       jQuery.each(this.values, function (index, value) {
         var option_elt = jQuery(document.createElement('option'))
@@ -480,6 +483,7 @@ BestInPlaceEditor.forms = {
 
   "checkbox" : {
     activateForm : function() {
+      this.element_type = 'span';
       this.collectionValue = !this.getValue();
       this.setHtmlAttributes();
       this.update();
@@ -495,6 +499,7 @@ BestInPlaceEditor.forms = {
       // grab width and height of text
       width = this.element.css('width');
       height = this.element.css('height');
+      this.element_type = this.formType;
 
       // construct form
       var output   = jQuery(document.createElement('form'))


### PR DESCRIPTION
This addresses issue #293

There is no element type called "date" for the date datatype so setHtmlAttributes is not

setting the attributes on the correct element.  Added this.element_type to store an
element_type per datatype
