### PR TITLE
Fixed bad API call to jQuery.attr()

### DIFF
--- a/lib/assets/javascripts/jquery.purr.js
+++ b/lib/assets/javascripts/jquery.purr.js
@@ -53,7 +53,7 @@
       // Set up the close button
       var close = document.createElement('a');
       jQuery(close).attr({
-          className: 'close',
+          class: 'close',
           href: '#close'
           }).appendTo(notice).click(function() {
               removeNotice();


### PR DESCRIPTION
Not sure if this problem still exists upstream, but the buggy version makes '<a className="close"...' instead of '<a class="close"...'
