### PR TITLE
Wrap data attributes in single quotes

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -63,7 +63,7 @@ module BestInPlace
           if !v.is_a?(String) && !v.is_a?(Symbol)
             v = v.to_json
           end
-          out << %( data-#{k.to_s.dasherize}="#{v}")
+          out << %( data-#{k.to_s.dasherize}='#{v}')
         end
       end
       if !opts[:sanitize].nil? && !opts[:sanitize]


### PR DESCRIPTION
To avoid breakage when passing along JSON serialized data.
