### PR TITLE
fixing text area reverting to current element text instead of server's response text

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -241,9 +241,9 @@ BestInPlaceEditor.prototype = {
     if(data && data!=""){
       var response = jQuery.parseJSON(jQuery.trim(data));
       if (response !== null && response.hasOwnProperty("display_as")) {
+        this.element.html(response["display_as"]);
         this.element.attr("data-original-content", this.element.text());
         this.original_content = this.element.text();
-        this.element.html(response["display_as"]);
       }
 
       this.element.trigger(jQuery.Event("best_in_place:success"), data);


### PR DESCRIPTION
I was having a problem in my app, where the BIP text area element being edited was reverting to the nil option value on second click.
This was a similar behavior to https://github.com/bernat/best_in_place/issues/53

Upon some investigation I concluded that the problem was in the order of execution of instructions in the `loadSuccessCallback`, which currently is:

```
...
this.element.attr("data-original-content", this.element.text());
this.original_content = this.element.text();
this.element.html(response["display_as"]);
...
```

(https://github.com/bernat/best_in_place/blob/master/lib/assets/javascripts/best_in_place.js#L238)

Since AJAX is asynchronous (as the name states), you should not trust that the value of the element (`this.element.text()`) will stay the same during the AJAX request. Just imagine that between the AJAX request and the time the server response arrives, the text has changed (easy to accomplish programmatically)

I've changed the order of execution so that the _data-original-content_ value is set to the value sent in the server response. 

I think this makes sense, but I don't know if there are some edge cases this change can crash.
