### PR TITLE
Show that bip_select is broken when changing from an earlier option to a later option, and provide a fix.

### DIFF
--- a/lib/best_in_place/test_helpers.rb
+++ b/lib/best_in_place/test_helpers.rb
@@ -33,6 +33,7 @@ module BestInPlace
         (function() {
           jQuery("##{id}").click();
           var opt_value = jQuery("##{id} select option:contains('#{name}')").attr('value');
+          jQuery("##{id} select option").attr('selected', false);
           jQuery("##{id} select option[value='" + opt_value + "']").attr('selected', true);
           jQuery("##{id} select").change();
         })();

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -224,6 +224,15 @@ describe "JS behaviour", :js => true do
     within("#country") do
       page.should have_content("France")
     end
+
+    # Now change it back:
+    
+    bip_select @user, :country, "Italy"
+
+    visit user_path(@user)
+    within("#country") do
+      page.should have_content("Italy")
+    end
   end
 
   it "should apply the inner_class option to a select field" do


### PR DESCRIPTION
bip_select does not remove the `selected` attribute from `<option>` tags, so if you use it to select an option further down from one already selected, the browser will submit the wrong value.
