### PR TITLE
add best_in_place:beforeUpdate event

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -78,6 +78,14 @@ BestInPlaceEditor.prototype = {
       this.abort();
       return true;
     }
+
+    var beforeEvent = jQuery.Event("best_in_place:beforeUpdate");
+    editor.element.trigger(beforeEvent);
+    if(beforeEvent.isPropagationStopped()){
+      this.abort();
+      return true;
+    }
+
     editor.ajax({
       "type"       : "post",
       "dataType"   : "text",


### PR DESCRIPTION
Added best_in_place:beforeUpdate event. So now you can do this:

$(document).on 'best_in_place:beforeUpdate', '.hot_class', (event) ->
    // some checks
    event.stopPropagation()

And request will aborted.
