### PR TITLE
Allowing for custom :value for original-content. Fixes #364

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   - Deprecated opts[:sanitize] in favor of option[:raw]
   - You have to require jquery.purr  before best_in_place.purr 
   - You have to require jquery-ui.datepicker  before best_in_place.jquery-ui 
+  - Added opts[:value] to set custom original-value
 
 - v.2x : glitch in the Matrix
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
 - **:as**: Used for overriding the default params key used for the object (the data-object attribute). Useful for e.g. STI scenarios where best_in_place should post to a common controller for different models.
 - **:data**: Hash of custom data attributes to be added to span. Can be used to provide data to the ajax:success callback.
 - **:class**: Additional classes to apply to the best_in_place span.  Accepts either a string or Array of strings
+- **:value**: Customize the starting value of the inline input (defaults to to the field's value)
 
 ###best_in_place_if
 **best_in_place_if condition, object, field, OPTIONS**

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -51,7 +51,7 @@ module BestInPlace
       options[:data]['bip-ok-button-class'] = opts[:ok_button_class].presence
       options[:data]['bip-cancel-button'] = opts[:cancel_button].presence
       options[:data]['bip-cancel-button-class'] = opts[:cancel_button_class].presence
-      options[:data]['bip-original-content'] = html_escape(value).presence
+      options[:data]['bip-original-content'] = html_escape(opts[:value] || value).presence
 
       options[:data]['bip-url'] = url_for(opts[:url] || object)
 
@@ -121,7 +121,7 @@ module BestInPlace
     def best_in_place_assert_arguments(args)
       args.assert_valid_keys(:id, :type, :nil, :classes, :collection, :data,
                              :activator, :cancel_button, :cancel_button_class, :html_attrs, :inner_class, :nil,
-                             :object_name, :ok_button, :ok_button_class, :display_as, :display_with, :path,
+                             :object_name, :ok_button, :ok_button_class, :display_as, :display_with, :path, :value,
                              :use_confirm, :confirm, :sanitize, :raw, :helper_options, :url, :place_holder, :class, :as, :param)
 
       best_in_place_deprecated_options(args)


### PR DESCRIPTION
Pretty simple tweak. However I've also encountered this: what's the distinction between `bip-original-content` and `bip-value`? They both pull the same stuff. Should `bip-value` also have this `opts[:value]` applied to it? I'd think probably?
