### PR TITLE
Allow HTML options to pass through, Allow 0 as place holder, Select inputs open with a single click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ spec/internal/tmp/**/*
 
 .rvmrc
 coverage
+tmp

--- a/README.md
+++ b/README.md
@@ -77,8 +77,7 @@ Params:
 Options:
 
 - **:type** It can be only [:input, :textarea, :select, :checkbox, :date (>= 1.0.4)] or if undefined it defaults to :input.
-- **:collection**: If you are using the :select type then you must specify the collection of values it takes as a hash where keys represent the display text and values are the option's value when selected. If you are
-  using the :checkbox type you can specify the two values it can take, or otherwise they will default to Yes and No.
+- **:collection**: If you are using the :select type then you must specify the collection of values it takes as a hash where values represent the display text and keys are the option's value when selected. If you are using the :checkbox type you can specify the two values it can take, or otherwise they will default to Yes and No.
 - **:url**: URL to which the updating action will be sent. If not defined it defaults to the :object path.
 - **:place_holder**: The nil param defines the content displayed in case no value is defined for that field. It can be something like "click me to edit".
   If not defined it will show *"-"*.
@@ -88,18 +87,30 @@ Options:
 - **:cancel_button**: (Inputs and textareas only) If set to a string, then a Cancel button will be shown with the string as its label.
 - **:cancel_button_class**: (Inputs and textareas only) Specifies any extra classes to set on the Cancel button.
 - **:sanitize**: True by default. If set to false the input/textarea will accept html tags.
-- **:html_attrs**: Hash of html arguments, such as maxlength, default-value etc.
+- **:html_attrs**: Hash of html arguments such as maxlength, default-value, etc. that will be set on the rendered input **not** the best_in_place span.  
 - **:inner_class**: Class that is set to the rendered input.
-- **:display_as**: A model method which will be called in order to display
-  this field.
+- **:display_as**: A **model** method which will be called in order to display this field. Cannot be used when using `display_with`.
+- **:display_with**: A **helper** method or proc will be called in order to display this field. Cannot be used with `display_as`.
+- **:helper_options**: A hash of parameters to be sent to the helper method specified by `display_with`.
 - **:as**: Used for overriding the default params key used for the object (the data-object attribute). Useful for e.g. STI scenarios where best_in_place should post to a common controller for different models.
 - **:data**: Hash of custom data attributes to be added to span. Can be used to provide data to the ajax:success callback.
 - **:class**: Additional classes to apply to the best_in_place span.  Accepts either a string or Array of strings
 - **:value**: Customize the starting value of the inline input (defaults to to the field's value)
+- **:id**: The HTML id of the best_in_place span. If not specified one is automatically generated.
+- **:param**: If you wish to specific the object explicitly use this option.
+- **:confirm**: If set to true displays a confirmation message when abandoning changes (pressing the escape key);
+
+HTML Options:  
+
+If you provide an option that is not explicitly a best_in_place option it will be passed through when creating the best_in_place span.
+
+So, for instance, if you want to add an HTML tab index to the best_in_place span just add it to your method call:
+
+    <%= best_in_place @user, :name, tabindex: "1" %>
 
 ###best_in_place_if
 **best_in_place_if condition, object, field, OPTIONS**
-see also **best_in_place_unless
+see also **best_in_place_unless**
 
 It allows us to use best_in_place only if the first new parameter, a
 condition, is satisfied. Specifically:
@@ -123,7 +134,7 @@ It is a very useful feature to use with, for example, [Ryan Bates](https://githu
 
 ---
 
-##Examples
+## Examples
 
 Examples (code in the views):
 
@@ -144,7 +155,7 @@ Examples (code in the views):
     <%= best_in_place @user, :country, :type => :select, :collection => {"1" => "Spain", "2" => "Italy", "3" => "Germany", "4" => "France"} %>
 
 Of course it can take an instance or global variable for the collection, just remember the structure is a hash.
-The key will always be converted to a string for display. *
+The value will always be converted to a string for display.
 
 ### Checkbox
 
@@ -269,7 +280,7 @@ In the view, we'd do:
           th= flavour
       - sizes.each do |size|
         tr
-          %th= size
+          th= size
           - flavours.each do |flavour|
             - v = @ice_cream.get_stock(flavour: flavour, size: size)
             td= best_in_place v, :to_i, type: :input, url: set_stock_ice_cream_path(flavour: flavour, size: size)
@@ -353,7 +364,10 @@ Fork the project on [github](https://github.com/bernat/best_in_place 'bernat / b
 
 ### Run the specs
 
+    $ appraisal
     $ appraisal rspec
+
+You many need to install appraisal: `gem install appraisal`
 
 ---
 

--- a/gemfiles/rails_3.2.gemfile
+++ b/gemfiles/rails_3.2.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 source "https://rails-assets.org"
 
+gem "activerecord"
 gem "rails-assets-jquery", "1.11.1"
 gem "rails-assets-jquery-ui", "1.10.4"
 gem "rdiscount"

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 source "https://rails-assets.org"
 
+gem "activerecord"
 gem "rails-assets-jquery", "1.11.1"
 gem "rails-assets-jquery-ui", "1.10.4"
 gem "rdiscount"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 source "https://rails-assets.org"
 
+gem "activerecord"
 gem "rails-assets-jquery", "1.11.1"
 gem "rails-assets-jquery-ui", "1.10.4"
 gem "rdiscount"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -3,6 +3,7 @@
 source "https://rubygems.org"
 source "https://rails-assets.org"
 
+gem "activerecord"
 gem "rails-assets-jquery", "1.11.1"
 gem "rails-assets-jquery-ui", "1.10.4"
 gem "rdiscount"

--- a/lib/assets/javascripts/best_in_place.jquery-ui.js
+++ b/lib/assets/javascripts/best_in_place.jquery-ui.js
@@ -18,6 +18,7 @@ BestInPlaceEditor.forms.date = {
                 .attr('type', 'text')
                 .attr('name', this.attributeName)
                 .attr('value', this.sanitizeValue(this.display_value));
+                
         if (this.inner_class !== null) {
             input_elt.addClass(this.inner_class);
         }

--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -191,16 +191,22 @@ BestInPlaceEditor.prototype = {
         self.okButtonClass = self.element.data("bipOkButtonClass") || self.okButtonClass || BestInPlaceEditor.defaults.okButtonClass;
         self.cancelButton = self.element.data("bipCancelButton") || self.cancelButton;
         self.cancelButtonClass = self.element.data("bipCancelButtonClass") || self.cancelButtonClass || BestInPlaceEditor.defaults.cancelButtonClass;
-        self.placeHolder = self.element.data("bipPlaceholder") || BestInPlaceEditor.defaults.locales[''].placeHolder;
+        
+        // Fix for default values of 0
+        if (self.element.data("bipPlaceholder") == null) {
+          self.placeHolder = BestInPlaceEditor.defaults.locales[''].placeHolder;
+        } else {
+          self.placeHolder = self.element.data("bipPlaceholder");
+        }
+        
         self.inner_class = self.element.data("bipInnerClass");
         self.html_attrs = self.element.data("bipHtmlAttrs");
         self.original_content = self.element.data("bipOriginalContent") || self.original_content;
-
+        
         // if set the input won't be satinized
         self.display_raw = self.element.data("bip-raw");
 
         self.useConfirm = self.element.data("bip-confirm");
-
 
         if (self.formType === "select" || self.formType === "checkbox") {
             self.values = self.collection;
@@ -471,6 +477,17 @@ BestInPlaceEditor.forms = {
             this.element.find("select").bind('blur', {editor: this}, BestInPlaceEditor.forms.select.blurHandler);
             this.element.find("select").bind('keyup', {editor: this}, BestInPlaceEditor.forms.select.keyupHandler);
             this.element.find("select")[0].focus();
+
+            // automatically click on the select so you
+            // don't have to click twice
+            try {
+              var e = document.createEvent("MouseEvents");
+              e.initMouseEvent("mousedown", true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+              this.element.find("select")[0].dispatchEvent(e);
+            } 
+            catch(e) {
+              // browser doesn't support this, e.g. IE8 
+            }
         },
 
         getValue: function () {

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -1,6 +1,7 @@
 module BestInPlace
   module Helper
     def best_in_place(object, field, opts = {})
+      
       best_in_place_assert_arguments(opts)
       type = opts[:as] || :input
       field = field.to_s
@@ -38,6 +39,8 @@ module BestInPlace
 
       options[:class] = ['best_in_place'] + Array(opts[:class] || opts[:classes])
       options[:id] = opts[:id] || BestInPlace::Utils.build_best_in_place_id(real_object, field)
+
+      pass_through_html_options(opts, options)
 
       options[:data]['bip-activator'] = opts[:activator].presence
 
@@ -82,6 +85,16 @@ module BestInPlace
 
     private
 
+    def pass_through_html_options(opts, options)
+      known_keys = [:id, :type, :nil, :classes, :collection, :data,
+                    :activator, :cancel_button, :cancel_button_class, :html_attrs, :inner_class, :nil,
+                    :object_name, :ok_button, :ok_button_class, :display_as, :display_with, :path, :value,
+                    :use_confirm, :confirm, :sanitize, :raw, :helper_options, :url, :place_holder, :class,
+                    :as, :param, :container]
+      uknown_keys = opts.keys - known_keys
+      uknown_keys.each { |key| options[key] = opts[key] }
+    end
+
     def best_in_place_build_value_for(object, field, opts)
       klass = object.class
       if opts[:display_as]
@@ -102,8 +115,6 @@ module BestInPlace
           if field_value.blank?
             ''
           else
-
-
             BestInPlace::ViewHelpers.send(opts[:display_with], field_value)
           end
         end
@@ -118,12 +129,6 @@ module BestInPlace
     end
 
     def best_in_place_assert_arguments(args)
-      args.assert_valid_keys(:id, :type, :nil, :classes, :collection, :data,
-                             :activator, :cancel_button, :cancel_button_class, :html_attrs, :inner_class, :nil,
-                             :object_name, :ok_button, :ok_button_class, :display_as, :display_with, :path, :value,
-                             :use_confirm, :confirm, :sanitize, :raw, :helper_options, :url, :place_holder, :class,
-                             :as, :param, :container)
-
       best_in_place_deprecated_options(args)
 
       if args[:display_as] && args[:display_with]

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -123,12 +123,12 @@ describe BestInPlace::Helper, type: :helper do
         end
       end
 
-      describe "nil option" do
-        it "should have no nil data by default" do
+      describe "placeholder option" do
+        it "should have no placeholder data by default" do
           expect(@span.attribute("data-bip-placeholder")).to be_nil
         end
 
-        it "should show '' if the object responds with nil for the passed attribute" do
+        it "should show '' if the object responds with placeholder for the passed attribute" do
           expect(@user).to receive(:name).twice.and_return("")
           nk = Nokogiri::HTML.parse(helper.best_in_place @user, :name)
           span = nk.css("span")
@@ -141,6 +141,7 @@ describe BestInPlace::Helper, type: :helper do
           span = nk.css("span")
           expect(span.text).to eq("")
         end
+        
       end
 
       it "should have the given inner_class" do
@@ -458,6 +459,24 @@ describe BestInPlace::Helper, type: :helper do
           end
         end
       end
+      
+      describe "with html parameters" do
+        before do
+          @attrs = {tabindex: 1, width: "300px", height: "24px"}
+          nk = Nokogiri::HTML.parse(helper.best_in_place @user, :name, @attrs)
+          @span = nk.css("span")
+        end
+        
+        it 'should pass through html attributes to the best_in_place span' do
+          expect(@attrs.select {|key, value| @span.attribute(key.to_s) }).to eq(@attrs)
+        end
+        
+        it 'should have the proper values set' do
+          expect(@attrs.map {|key, value| @span.attribute(key.to_s).value }).to eq(@attrs.map {|key, value| value.to_s })
+        end
+        
+      end
+      
     end
 
     context 'custom container' do

--- a/spec/integration/placeholder_spec.rb
+++ b/spec/integration/placeholder_spec.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+describe "Placeholder behavior", :js => true do
+  before do
+    @user = User.new name: "Zero",
+      last_name: "My Hero",
+      address: "0 Nowhere lane",
+      email: "zero@zero.com",
+      height: "0",
+      zip: "00000",
+      description: ""                    
+  end
+
+  it "should set a place_holder value" do
+    @user.save!
+    visit user_path(@user)
+    expect(find('#favorite_locale')).to have_content("N/A")
+  end
+
+  it "should allow the use of 0 for a placeholder" do
+    @user.save!
+    visit user_path(@user)
+    expect(find('#zero_field')).to have_content("0")
+  end
+
+end

--- a/spec/internal/app/views/users/show.html.erb
+++ b/spec/internal/app/views/users/show.html.erb
@@ -102,7 +102,7 @@
     <tr>
       <td>Money</td>
       <td id="money">
-        <%= best_in_place @user, :money, :display_with => :number_to_currency %>
+        <%= best_in_place @user, :money, :display_with => :number_to_currency%>
       </td>
     </tr>
     <tr>
@@ -131,6 +131,13 @@
         <%= best_in_place @user, :favorite_movie, opts %>
       </td>
     </tr>
+    <tr>
+      <td>Zero Field</td>
+      <td id="zero_field">
+        <%= best_in_place @user, :zero_field, place_holder: 0 %>
+      </td>
+    </tr>
+    
   </table>
   <br/>
   <hr/>

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -22,5 +22,6 @@ ActiveRecord::Schema.define do
     t.string   "height"
     t.string   "favorite_movie"
     t.string   "favorite_locale"
+    t.integer  "zero_field"
   end
 end

--- a/spec/support/retry_on_timeout.rb
+++ b/spec/support/retry_on_timeout.rb
@@ -2,6 +2,6 @@ def retry_on_timeout(n = 3, &block)
   block.call
 rescue => e
   fail if n.zero?
-  puts "Catched error: #{e.message}. #{n-1} more attempts."
+  puts "Caught error: #{e.message}. #{n-1} more attempts."
   retry_on_timeout(n - 1, &block)
 end


### PR DESCRIPTION
It's much more useful to allow HTML parameters to pass through than blocking any parameter that isn't a best_in_place parameter. This small updated does exactly that.

Other changes:
Fixed a bug that didn't allow 0 (zero) to be used as a place holder.
Select inputs open immediately when clicked so don't require two clicks.
