### PR TITLE
Disable other handlers when escaping from an BIP input

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -439,6 +439,7 @@ BestInPlaceEditor.forms = {
             'use strict';
             if (event.keyCode === 27) {
                 event.data.editor.abort();
+                event.stopImmediatePropagation();
             }
         }
     },


### PR DESCRIPTION
It’s confusing when some elements react to an Escape event, when you just wanted to discard changes in an input box. This can be prevented.
