### PR TITLE
Always pass on all $.ajax callback arguments

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -106,8 +106,8 @@ BestInPlaceEditor.prototype = {
             "type": BestInPlaceEditor.defaults.ajaxMethod,
             "dataType": BestInPlaceEditor.defaults.ajaxDataType,
             "data": editor.requestData(),
-            "success": function (data) {
-                editor.loadSuccessCallback(data);
+            "success": function (data, status, xhr) {
+                editor.loadSuccessCallback(data, status, xhr);
             },
             "error": function (request, error) {
                 editor.loadErrorCallback(request, error);
@@ -282,7 +282,7 @@ BestInPlaceEditor.prototype = {
 
     // Handlers ////////////////////////////////////////////////////////////////
 
-    loadSuccessCallback: function (data) {
+    loadSuccessCallback: function (data, status, xhr) {
         'use strict';
         data = jQuery.trim(data);
         //Update original content with current text.
@@ -298,13 +298,11 @@ BestInPlaceEditor.prototype = {
                 this.element.data('bip-original-content', this.element.text());
                 this.element.html(response.display_as);
             }
-
-            this.element.trigger(jQuery.Event("best_in_place:success"), data);
-            this.element.trigger(jQuery.Event("ajax:success"), data);
-        } else {
-            this.element.trigger(jQuery.Event("best_in_place:success"));
-            this.element.trigger(jQuery.Event("ajax:success"));
         }
+
+        this.element.trigger(jQuery.Event("best_in_place:success"), [data, status, xhr]);
+        this.element.trigger(jQuery.Event("ajax:success"), [data, status, xhr]);
+
         // Binding back after being clicked
         jQuery(this.activator).bind('click', {editor: this}, this.clickHandler);
         this.element.trigger(jQuery.Event("best_in_place:deactivate"));


### PR DESCRIPTION
This changes the JS so that it passes all arguments that the callbacks you define for `$.ajax` receive on to event handlers for the `"best_in_place:success"` and `"ajax:success"` events.

This is helpful if you need to access e.g. response headers etc.