### PR TITLE
Add DOM update after jQuery data update.

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -140,6 +140,7 @@ BestInPlaceEditor.prototype = {
         }
 
         editor.element.data('bipValue', value);
+        editor.element.attr('data-bip-value', value);
 
         editor.element.trigger(jQuery.Event("best_in_place:update"));
 

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -111,6 +111,17 @@ describe "JS behaviour", :js => true do
     end
   end
 
+  it 'should update the DOM when a field value changes' do
+    @user.save!
+    visit user_path(@user)
+
+    expect(find('#receive_email')).to have_content('No thanks')
+
+    bip_bool @user, :receive_email
+
+    expect(page).to have_selector('#receive_email span[data-bip-value=true]')
+  end
+
   it "should be able to update last but one item in list" do
     @user.save!
     @user2 = User.create :name => "Test",


### PR DESCRIPTION
It turns out that $(selector).data(attribute, value) does not modify
the underlying DOM. This prevents styling things based on the value
in, say, a checkbox. This change adds an additional update to the DOM
to keep it in sync with the jQuery cached data.