### PR TITLE
Support Bootstrap Datepicker with locales 

### DIFF
--- a/lib/assets/javascripts/best_in_place.bootstrap3.js
+++ b/lib/assets/javascripts/best_in_place.bootstrap3.js
@@ -1,0 +1,60 @@
+/*
+ * BestInPlace 3.0.0.alpha (2014)
+ *
+ * Depends:
+ *	best_in_place.js
+ *	bootstrap-datepicker.js
+ */
+/*global BestInPlaceEditor */
+BestInPlaceEditor.forms.date = {
+    activateForm: function () {
+        'use strict';
+        var that = this,
+            output = jQuery(document.createElement('form'))
+                .addClass('form_in_place')
+                .attr('action', 'javascript:void(0);')
+                .attr('style', 'display:inline'),
+            input_elt = jQuery(document.createElement('input'))
+                .attr('type', 'text')
+                .attr('name', this.attributeName)
+                .attr('value', this.sanitizeValue(this.display_value));
+
+        if (this.inner_class !== null) {
+            input_elt.addClass(this.inner_class);
+        }
+        output.append(input_elt);
+
+        this.element.html(output);
+        this.setHtmlAttributes();
+        this.element.find('input')[0].select();
+        this.element.find("form").bind('submit', {editor: this}, BestInPlaceEditor.forms.input.submitHandler);
+        this.element.find("input").bind('keyup', {editor: this}, BestInPlaceEditor.forms.input.keyupHandler);
+
+        this.element.find('input')
+            .datepicker({
+                language: this.element.data('language')
+            }).on('hide', function(){
+                that.update();
+            }).on('changeDate', function(){
+                $(this).datepicker('hide');
+            })
+            .datepicker('show');
+    },
+
+    getValue: function () {
+        'use strict';
+        return this.sanitizeValue(this.element.find("input").val());
+    },
+
+    submitHandler: function (event) {
+        'use strict';
+        event.data.editor.update();
+    },
+
+    keyupHandler: function (event) {
+        'use strict';
+        if (event.keyCode === 27) {
+            event.data.editor.abort();
+        }
+    }
+}


### PR DESCRIPTION
Requirement:
Bootstrap3
Bootstrap Datepicker

Usage:
In application.js add: //= require best_in_place.bootstrap3
In your view use the best_in_place helper, set "as: date"

Optional:
Require a Bootstrap Datepicker language file in your application.js file
For german you could activate it by setting "data: {language: 'de'}" when using the best_in_place view helper