### PR TITLE
add skip_blur to configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,15 @@ And finally we need a controller:
 
 And this is how it is done!
 
+## Configuration
+
+You can configure some global options for best_in_place. Currently these options are available:
+
+    BestInPlace.configure do |config|
+      config.container = :div
+      config.skip_blur = true
+    end
+    
 
 ## Notification
 

--- a/lib/best_in_place.rb
+++ b/lib/best_in_place.rb
@@ -14,10 +14,11 @@ module BestInPlace
   end
 
   class Configuration
-    attr_accessor :container
+    attr_accessor :container, :skip_blur
 
     def initialize
       @container = :span
+      @skip_blur = false
     end
   end
 

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -49,7 +49,7 @@ module BestInPlace
       options[:data]['bip-cancel-button-class'] = opts[:cancel_button_class].presence
       options[:data]['bip-original-content'] = html_escape(opts[:value] || value).presence
 
-      options[:data]['bip-skip-blur'] = opts[:skip_blur].presence
+      options[:data]['bip-skip-blur'] = opts[:skip_blur].presence || BestInPlace.skip_blur
 
       options[:data]['bip-url'] = url_for(opts[:url] || object)
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -521,6 +521,25 @@ describe BestInPlace::Helper, type: :helper do
         BestInPlace.container = @old_container
       end
     end
+
+    context '.configure' do
+      describe 'skip_blur' do
+        before(:each) do
+          @old_skip_blur = BestInPlace.skip_blur
+          @user.save
+          BestInPlace.skip_blur  = true
+        end
+
+        after(:each) do
+          BestInPlace.skip_blur = @old_skip_blur
+        end
+
+        it 'should override blur globally' do
+          nk = Nokogiri::HTML.parse(helper.best_in_place(@user, :name))
+          expect(nk.css("span").attribute("data-bip-skip-blur").value).to eq("true")
+        end
+      end
+    end
   end
 
   describe "#best_in_place_if" do


### PR DESCRIPTION
### What does this PR do?

- Allows for global `skip_blur` configuration option:

```ruby
# inside config/initializers/best_in_place.rb

BestInPlace.configure do |config|
  config.skip_blur = true
end
```
