### PR TITLE
allows for skip_blur config to be overridden on attribute...

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -49,7 +49,7 @@ module BestInPlace
       options[:data]['bip-cancel-button-class'] = opts[:cancel_button_class].presence
       options[:data]['bip-original-content'] = html_escape(opts[:value] || value).presence
 
-      options[:data]['bip-skip-blur'] = opts[:skip_blur].presence || BestInPlace.skip_blur
+      options[:data]['bip-skip-blur'] = opts.has_key?(:skip_blur) ? opts[:skip_blur].presence : BestInPlace.skip_blur
 
       options[:data]['bip-url'] = url_for(opts[:url] || object)
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -538,6 +538,11 @@ describe BestInPlace::Helper, type: :helper do
           nk = Nokogiri::HTML.parse(helper.best_in_place(@user, :name))
           expect(nk.css("span").attribute("data-bip-skip-blur").value).to eq("true")
         end
+
+        it 'should use helper params' do
+          nk = Nokogiri::HTML.parse(helper.best_in_place(@user, :name, skip_blur: false))
+          expect(nk.css("span").attribute("data-bip-skip-blur")).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
This should have been included with #469 - it was a small oversight. 

now if you set `skip_blur` globally, you can choose specific inputs to use the blur.