### PR TITLE
fixed jquery.purr to make it play nciely with YUICompressor

### DIFF
--- a/vendor/assets/javascripts/jquery.purr.js
+++ b/vendor/assets/javascripts/jquery.purr.js
@@ -53,7 +53,7 @@
       // Set up the close button
       var close = document.createElement('a');
       jQuery(close).attr({
-          class: 'close',
+          'class': 'close',
           href: '#close'
           }).appendTo(notice).click(function() {
               removeNotice();


### PR DESCRIPTION
jquery.purr was breaking YUICompressor (sstephenson/ruby-yui-compressor) -- YUICompressor couldn't compress jquery.purr because `class` is a reserved keyword.

This may also fix #423--I'm not really sure but it looked related at first glance.