### PR TITLE
If bip field does not support raw format prevent xss when passsing html tags

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -286,7 +286,13 @@ BestInPlaceEditor.prototype = {
             var response = jQuery.parseJSON(data);
             if (response !== null && response.hasOwnProperty("display_as")) {
                 this.element.data('bip-original-content', this.element.text());
-                this.element.html(response.display_as);
+                var displayValue = response.display_as;
+
+                if (this.display_raw) {
+                    var displayValue = $('<div>').html(response.display_as).text();
+                }
+
+                this.element.html(displayValue);
             }
         }
 

--- a/lib/best_in_place/display_methods.rb
+++ b/lib/best_in_place/display_methods.rb
@@ -6,7 +6,7 @@ module BestInPlace
       def render_json(object)
         case opts[:type]
           when :model
-            { display_as: object.send(opts[:method]) }.to_json
+            { display_as: CGI.escapeHTML(object.send(opts[:method])) }.to_json
           when :helper
             value = if opts[:helper_options]
                       BestInPlace::ViewHelpers.send(opts[:method], object.send(opts[:attr]), opts[:helper_options])

--- a/spec/integration/js_spec.rb
+++ b/spec/integration/js_spec.rb
@@ -614,6 +614,18 @@ describe "JS behaviour", :js => true do
         expect(text).to eq("A's & B's")
       end
     end
+
+    it 'should prevent xss saving correct html string' do
+      @user.save!
+
+      retry_on_timeout do
+        visit user_path(@user)
+
+        bip_text @user, :address, "<script>alert('hi');</script>"
+        wait_for_ajax
+        expect(page).to have_css('#address', text: "<script>alert('hi');</script>")
+      end
+    end
   end
 
   describe "display_with" do


### PR DESCRIPTION
When it's not suppossed to display html tags it's turned out that there is XSS. You may reproduce this issue when editing field without `raw` data attribute and passing `<script>alert('XSS')</script>`. 

Right now server always responds with escaped values. It unescapes values only if `raw` is enabled.
