### PR TITLE
Make popup with validation errors working in IE8

### DIFF
--- a/vendor/assets/javascripts/jquery.purr.js
+++ b/vendor/assets/javascripts/jquery.purr.js
@@ -53,7 +53,7 @@
       // Set up the close button
       var close = document.createElement('a');
       jQuery(close).attr({
-          class: 'close',
+          'class': 'close',
           href: '#close'
           }).appendTo(notice).click(function() {
               removeNotice();


### PR DESCRIPTION
Seems that class is a reserved word in IE8, so wrap it in quotes