### PR TITLE
Apply a class when the placeholder text is used.

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -134,11 +134,13 @@ BestInPlaceEditor.prototype = {
                     } else {
                         editor.element.text(value);
                     }
+                    editor.element.removeClass('bip_placeholder');
                 } else {
+                    editor.element.addClass('bip_placeholder');
                     editor.element.html(this.placeHolder);
                 }
         }
-
+        console.debug(value);
         editor.element.data('bipValue', value);
         editor.element.attr('data-bip-value', value);
 
@@ -223,6 +225,7 @@ BestInPlaceEditor.prototype = {
         'use strict';
         // TODO add placeholder for select and checkbox
         if (this.element.html() === "") {
+            this.element.addClass('bip_placeholder');
             this.element.html(this.placeHolder);
         }
     },
@@ -658,6 +661,3 @@ jQuery.fn.best_in_place = function () {
 
     return this;
 };
-
-
-

--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -140,7 +140,6 @@ BestInPlaceEditor.prototype = {
                     editor.element.html(this.placeHolder);
                 }
         }
-        console.debug(value);
         editor.element.data('bipValue', value);
         editor.element.attr('data-bip-value', value);
 


### PR DESCRIPTION
Typically placeholders are shown in a muted text for input values.  To emulate this, I have added the application of the .bip_placeholder class when the placeholder is used in place of nil values.  This will allow the developer to style the placeholder different that the real value.