### PR TITLE
Calls new Capybara.default_max_wait_time to surpress deprecation warning

### DIFF
--- a/lib/best_in_place.rb
+++ b/lib/best_in_place.rb
@@ -14,11 +14,12 @@ module BestInPlace
   end
 
   class Configuration
-    attr_accessor :container, :skip_blur
+    attr_accessor :container, :skip_blur, :default_max_execution_time_in_seconds
 
     def initialize
       @container = :span
       @skip_blur = false
+      @default_max_execution_time_in_seconds = 30
     end
   end
 

--- a/lib/best_in_place/test_helpers.rb
+++ b/lib/best_in_place/test_helpers.rb
@@ -44,7 +44,7 @@ module BestInPlace
       evaluate_script('!window.jQuery') || evaluate_script('jQuery.active').zero?
     end
 
-    def wait_until(max_execution_time_in_seconds = Capybara.default_wait_time)
+    def wait_until(max_execution_time_in_seconds = default_max_execution_time_in_seconds)
       Timeout.timeout(max_execution_time_in_seconds) do
         loop do
           if yield
@@ -57,5 +57,14 @@ module BestInPlace
       end
     end
 
+    def default_max_execution_time_in_seconds
+      return BestInPlace.default_max_execution_time_in_seconds unless defined?(Capybara)
+
+      if Capybara.respond_to? :default_max_wait_time
+        Capybara.default_max_wait_time
+      else
+        Capybara.default_wait_time
+      end
+    end
   end
 end


### PR DESCRIPTION
Deprecation message:
DEPRECATED: #default_wait_time is deprecated, please use #default_max_wait_time instead

This code is probably excessively complicated.  I introduced a new configuration option with the goal in mind to remove the hard dependency Capybara.default_wait_time in BestInPlace::TestHelpers#wait_until.
