### PR TITLE
Add ability to use BIP to create new records

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -303,7 +303,7 @@ BestInPlaceEditor.prototype = {
             if (this.isNewObject && response && response[this.objectName]) {
                 if (response[this.objectName]["id"]) {
                     this.isNewObject = false
-                    this.url += "/" + response[this.objectName]["id"] // TODO is this kosher with REST? maybe?
+                    this.url += "/" + response[this.objectName]["id"] // in REST a POST /thing url should become PUT /thing/123
                 }
             }
         }

--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -103,7 +103,7 @@ BestInPlaceEditor.prototype = {
         }
 
         editor.ajax({
-            "type": BestInPlaceEditor.defaults.ajaxMethod,
+            "type": this.requestMethod(),
             "dataType": BestInPlaceEditor.defaults.ajaxDataType,
             "data": editor.requestData(),
             "success": function (data, status, xhr) {
@@ -189,6 +189,8 @@ BestInPlaceEditor.prototype = {
         self.cancelButton = self.element.data("bipCancelButton") || self.cancelButton;
         self.cancelButtonClass = self.element.data("bipCancelButtonClass") || self.cancelButtonClass || BestInPlaceEditor.defaults.cancelButtonClass;
         self.skipBlur = self.element.data("bipSkipBlur") || self.skipBlur || BestInPlaceEditor.defaults.skipBlur;
+        self.isNewObject = self.element.data("bipNewObject");
+        self.dataExtraPayload = self.element.data("bipExtraPayload");
 
         // Fix for default values of 0
         if (self.element.data("bipPlaceholder") == null) {
@@ -246,6 +248,11 @@ BestInPlaceEditor.prototype = {
         return jQuery.trim(s);
     },
 
+    requestMethod: function() {
+        'use strict';
+        return this.isNewObject ? 'post' : BestInPlaceEditor.defaults.ajaxMethod;
+    },
+
     /* Generate the data sent in the POST request */
     requestData: function () {
         'use strict';
@@ -253,13 +260,17 @@ BestInPlaceEditor.prototype = {
         var csrf_token = jQuery('meta[name=csrf-token]').attr('content'),
             csrf_param = jQuery('meta[name=csrf-param]').attr('content');
 
-        var data = "_method=" + BestInPlaceEditor.defaults.ajaxMethod;
-        data += "&" + this.objectName + '[' + this.attributeName + ']=' + encodeURIComponent(this.getValue());
+        var data = {}
+        data['_method'] = this.requestMethod()
+
+        data[this.objectName] = this.dataExtraPayload || {}
+
+        data[this.objectName][this.attributeName] = this.getValue()
 
         if (csrf_param !== undefined && csrf_token !== undefined) {
-            data += "&" + csrf_param + "=" + encodeURIComponent(csrf_token);
+            data[csrf_param] = csrf_token
         }
-        return data;
+        return jQuery.param(data);
     },
 
     ajax: function (options) {
@@ -288,6 +299,12 @@ BestInPlaceEditor.prototype = {
             if (response !== null && response.hasOwnProperty("display_as")) {
                 this.element.data('bip-original-content', this.element.text());
                 this.element.html(response.display_as);
+            }
+            if (this.isNewObject && response && response[this.objectName]) {
+                if (response[this.objectName]["id"]) {
+                    this.isNewObject = false
+                    this.url += "/" + response[this.objectName]["id"] // TODO is this kosher with REST? maybe?
+                }
             }
         }
         this.element.toggleClass('bip-placeholder', this.isPlaceHolder());
@@ -469,7 +486,10 @@ BestInPlaceEditor.forms = {
                 var option_elt = jQuery(document.createElement('option'))
                     .val(key)
                     .html(value);
-                if (String(key) === String(currentCollectionValue)) option_elt.attr('selected', 'selected');
+
+                if (currentCollectionValue) {
+                  if (String(key) === String(currentCollectionValue)) option_elt.attr('selected', 'selected');
+                }
                 select_elt.append(option_elt);
             });
             output.append(select_elt);

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -50,6 +50,12 @@ module BestInPlace
 
       options[:data]['bip-url'] = url_for(opts[:url] || object)
 
+      if real_object.respond_to?(:new_record?) and real_object.new_record?
+        options[:data]['bip-new-object'] = true
+        # collect name => value map of unsaved attributes to be serialized
+        options[:data]['bip-extra-payload'] = Hash[real_object.changes.map { |k,v| [k, v[1]] }]
+      end
+
       options[:data]['bip-confirm'] = opts[:confirm].presence
       options[:data]['bip-value'] = html_escape(value).presence
 

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -277,6 +277,42 @@ describe BestInPlace::Helper, type: :helper do
       end
     end
 
+    context "with a new record" do
+      before do
+        @new_user = User.new last_name: "Hortenz"
+      end
+
+      describe "url generation" do
+        it "should have the correct default url" do
+          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          span = nk.css("span")
+          expect(span.attribute("data-bip-url").value).to eq("/users")
+        end
+
+        it "should set the new-object data param" do
+          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          span = nk.css("span")
+          expect(span.attribute("data-bip-new-object").value).to be_truthy
+        end
+
+        # normally this would be used to set associations for new models , eg.
+        # `role_id` or `categories`, that would then be passed to the
+        # users#create method. Since the test model doesn't have associations,
+        # we'll just test that last_name works this way.
+        it "should set the extra-payload data param to a hash of all the unsaved attribs of the model" do
+          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          span = nk.css("span")
+          expect(span.attribute("data-bip-extra-payload").value).to eq '{"last_name":"Hortenz"}'
+        end
+
+        it "should have a proper id" do
+          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          span = nk.css("span")
+          expect(span.attribute("id").value).to eq("best_in_place_user_last_name")
+        end
+      end
+    end
+
     context "with a text field attribute" do
       before do
         nk = Nokogiri::HTML.parse(helper.best_in_place @user, :name)

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -277,38 +277,35 @@ describe BestInPlace::Helper, type: :helper do
       end
     end
 
-    context "with a new record" do
+    context "with a new record and associations" do
       before do
-        @new_user = User.new last_name: "Hortenz"
+        @user.save
+        @test_result = TestResult.new name: 'Meyers-Briggs', user_id: @user.id
       end
 
       describe "url generation" do
         it "should have the correct default url" do
-          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          nk = Nokogiri::HTML.parse(helper.best_in_place [:admin, @test_result], :result)
           span = nk.css("span")
-          expect(span.attribute("data-bip-url").value).to eq("/users")
+          expect(span.attribute("data-bip-url").value).to eq("/admin/test_results")
         end
 
         it "should set the new-object data param" do
-          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          nk = Nokogiri::HTML.parse(helper.best_in_place [:admin, @test_result], :result)
           span = nk.css("span")
           expect(span.attribute("data-bip-new-object").value).to be_truthy
         end
 
-        # normally this would be used to set associations for new models , eg.
-        # `role_id` or `categories`, that would then be passed to the
-        # users#create method. Since the test model doesn't have associations,
-        # we'll just test that last_name works this way.
         it "should set the extra-payload data param to a hash of all the unsaved attribs of the model" do
-          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+          nk = Nokogiri::HTML.parse(helper.best_in_place [:admin, @test_result], :result)
           span = nk.css("span")
-          expect(span.attribute("data-bip-extra-payload").value).to eq '{"last_name":"Hortenz"}'
+          expect(span.attribute("data-bip-extra-payload").value).to eq %Q!{"name":"Meyers-Briggs","user_id":#{@user.id}}!
         end
 
-        it "should have a proper id" do
-          nk = Nokogiri::HTML.parse(helper.best_in_place @new_user, :last_name)
+        it "should have a proper DOM id for the container" do
+          nk = Nokogiri::HTML.parse(helper.best_in_place [:admin, @test_result], :result)
           span = nk.css("span")
-          expect(span.attribute("id").value).to eq("best_in_place_user_last_name")
+          expect(span.attribute("id").value).to eq("best_in_place_test_result_result")
         end
       end
     end

--- a/spec/integration/new_record_spec.rb
+++ b/spec/integration/new_record_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-describe "JS behaviour", :js => true do
+describe "with new records", :js => true do
   before do
     @user = User.new :name => "Julian",
       :last_name => "Bronson",

--- a/spec/integration/new_record_spec.rb
+++ b/spec/integration/new_record_spec.rb
@@ -1,0 +1,70 @@
+# encoding: utf-8
+
+describe "JS behaviour", :js => true do
+  before do
+    @user = User.new :name => "Julian",
+      :last_name => "Bronson",
+      :email => "jbro@example.com",
+      :address => '1925 Park Ave',
+      :zip => '10001',
+      :description => 'Excellent at taking tests.'
+  end
+
+  it "should create new records with proper associations" do
+    @user.save!
+    expect(@user.test_results.length).to eq 0
+
+    visit admin_user_path(@user)
+    expect(find('#test-results-table')).to have_content('Meyers-Briggs')
+    expect(find('#test-results-table')).to have_content('Stanford-Binet')
+    expect(find('#test-results-table')).to have_content('SAT')
+
+    bip_text 'test_result_sat', :result, "1700"
+    bip_text 'test_result_stanford_binet', :result, "120"
+    bip_select 'test_result_meyers_briggs', :result, "INFJ"
+
+    @user.reload
+    expect(@user.test_results.length).to eq 3
+
+    visit admin_user_path(@user)
+
+    expect(find('#best_in_place_test_result_sat_result')).to have_content('1700')
+    expect(find('#best_in_place_test_result_stanford_binet_result')).to have_content('120')
+    expect(find('#best_in_place_test_result_meyers_briggs_result')).to have_content('INFJ')
+  end
+
+  it "should update persisted records as well" do
+    @user.save!
+    test_result = TestResult.new name: 'SAT', result: '1310', user_id: @user.id
+    test_result.save!
+
+    visit admin_user_path(@user)
+    expect(find('#best_in_place_test_result_sat_result')).to have_content('1310')
+
+    bip_text 'test_result_sat', :result, "1410"
+    bip_select 'test_result_meyers_briggs', :result, "ISFP"
+
+    visit admin_user_path(@user)
+
+    expect(find('#best_in_place_test_result_sat_result')).to have_content('1410')
+    expect(find('#best_in_place_test_result_meyers_briggs_result')).to have_content('ISFP')
+  end
+
+  it "should create new records then change the bip instance to updating the persited record" do
+    @user.save!
+
+    visit admin_user_path(@user)
+    bip_text 'test_result_stanford_binet', :result, "110"
+
+    @user.reload
+    expect(@user.test_results.length).to eq 1
+    expect(@user.test_results.first.result).to eq "110"
+
+    bip_text 'test_result_stanford_binet', :result, "120"
+
+    @user.test_results.reload
+    expect(@user.test_results.length).to eq 1
+    expect(@user.test_results.first.result).to eq "120"
+  end
+
+end

--- a/spec/internal/app/assets/stylesheets/application.css
+++ b/spec/internal/app/assets/stylesheets/application.css
@@ -1,0 +1,5 @@
+/*
+*= require scaffold.css
+*= require style.css
+*= require jquery-ui-1.8.16.custom.css
+*/

--- a/spec/internal/app/controllers/admin/test_results_controller.rb
+++ b/spec/internal/app/controllers/admin/test_results_controller.rb
@@ -1,0 +1,22 @@
+class Admin::TestResultsController < ApplicationController
+
+  def create
+    test_result = TestResult.new test_result_params
+    test_result.save!
+    render json: { test_result: test_result }
+  end
+
+  def update
+    @test_result = TestResult.find(params[:id])
+    @test_result.update_attributes(test_result_params)
+    respond_to do |format|
+      format.json { respond_with_bip(@test_result) }
+    end
+  end
+
+  private
+
+  def test_result_params
+    params[:test_result].permit!
+  end
+end

--- a/spec/internal/app/controllers/admin/test_results_controller.rb
+++ b/spec/internal/app/controllers/admin/test_results_controller.rb
@@ -3,7 +3,7 @@ class Admin::TestResultsController < ApplicationController
   def create
     test_result = TestResult.new test_result_params
     test_result.save!
-    render json: { test_result: test_result }
+    render json: test_result, root: true
   end
 
   def update

--- a/spec/internal/app/models/test_result.rb
+++ b/spec/internal/app/models/test_result.rb
@@ -1,0 +1,16 @@
+class TestResult < ActiveRecord::Base
+  belongs_to :user
+
+  AVAILABLE_TESTS = %w(Meyers-Briggs Stanford-Binet SAT)
+
+  def name_to_slug
+    name.downcase.gsub(/\W/, '_')
+  end
+
+  def options
+    if name == 'Meyers-Briggs'
+      %w( ISTJ ISFJ INFJ INTJ ISTP ISFP ).map { |v| [v, v] }
+    end
+  end
+
+end

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ActiveRecord::Base
 
   def tests
     TestResult::AVAILABLE_TESTS.map do |test_type|
-      test_results.find_by(name: test_type) || TestResult.new(name: test_type, user_id: id)
+      test_results.where(name: test_type).first || TestResult.new(name: test_type, user_id: id)
     end
   end
 end

--- a/spec/internal/app/models/user.rb
+++ b/spec/internal/app/models/user.rb
@@ -21,6 +21,8 @@ class User < ActiveRecord::Base
   alias_attribute :receive_email_image, :receive_email
   alias_attribute :description_simple, :description
 
+  has_many :test_results
+
   def address_format
     "<b>addr => [#{address}]</b>".html_safe
   end
@@ -31,5 +33,11 @@ class User < ActiveRecord::Base
 
   def zip_format
     nil
+  end
+
+  def tests
+    TestResult::AVAILABLE_TESTS.map do |test_type|
+      test_results.find_by(name: test_type) || TestResult.new(name: test_type, user_id: id)
+    end
   end
 end

--- a/spec/internal/app/views/admin/users/show.html.erb
+++ b/spec/internal/app/views/admin/users/show.html.erb
@@ -16,5 +16,19 @@
       </td>
     </tr>
   </table>
+
+  <table id="test-results-table">
+    <% @user.tests.each do |test| %>
+      <tr>
+        <td><%= test.name %></td>
+        <td>
+          <%= best_in_place [:admin, test], :result, as: test.options ? :select : :input,
+                                                     collection: test.options,
+                                                     id: "best_in_place_test_result_#{test.name_to_slug}_result"
+          %>
+        </td>
+      </tr>
+    <% end %>
+  </table>
 </div>
 

--- a/spec/internal/app/views/layouts/application.html.erb
+++ b/spec/internal/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Best In Place TEST APP <%= Rails::VERSION::STRING %></title>
-  <%= stylesheet_link_tag "scaffold", "style", "jquery-ui-1.8.16.custom" %>
+  <%= stylesheet_link_tag "application" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tag %>
 </head>

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users
+    resources :test_results, only: [:create, :update]
   end
 
   root :to => "users#index"

--- a/spec/internal/db/schema.rb
+++ b/spec/internal/db/schema.rb
@@ -24,4 +24,10 @@ ActiveRecord::Schema.define do
     t.string   "favorite_locale"
     t.integer  "zero_field"
   end
+
+  create_table "test_results", :force => true do |t|
+    t.string   "name"
+    t.string   "result"
+    t.integer  "user_id"
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,8 +12,12 @@ Capybara.javascript_driver = :poltergeist
 
 require 'best_in_place'
 
-Combustion.initialize! :active_record, :action_controller,
-                       :action_view, :sprockets
+Combustion.initialize! :active_record, :action_controller, :action_view, :sprockets do
+  config.assets.compile = true
+  config.assets.compress = false
+  config.assets.debug = false
+  config.assets.digest = false
+end
 
 require 'rspec/rails'
 require 'capybara/rails'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -26,4 +26,7 @@ RSpec.configure do |config|
   config.include BestInPlace::TestHelpers
   config.use_transactional_fixtures = false
   config.raise_errors_for_deprecations!
+
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
This use case is maybe a little unusual, but I hope the tests that are added around "TestResult" make it clear. We have a situation where a main model has a bunch of value associations that have to be filled out (and in reality the exact set of the values needed is dependent on a number of factors, *and* we can't pre-build a bunch of nil values). The schema is a basic [EAV](https://en.wikipedia.org/wiki/Entity%E2%80%93attribute%E2%80%93value_model) setup, but as in the tests, it could work with something de-normalized.

So the controller instantiates new, unsaved objects for the values - with the correct id's needed to build the associations - and passes each one to the `best_in_place` helper. When the field is submitted it's sent as a POST which creates the new value, and then the field is changed to be a "normal" BIP field that then does an update. So the values can be created lazily and only as-needed.

All one has to do then is pass an object that responds true for `new_record?` and the REST interaction should be adjusted accordingly.