### PR TITLE
Add explicit selector to input so getValue can get the correct element

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -371,6 +371,7 @@ BestInPlaceEditor.forms = {
                 .attr('action', 'javascript:void(0);')
                 .attr('style', 'display:inline');
             var input_elt = jQuery(document.createElement('input'))
+                .addClass('input_in_place')
                 .attr('type', 'text')
                 .attr('name', this.attributeName)
                 .val(this.display_value);
@@ -401,7 +402,7 @@ BestInPlaceEditor.forms = {
 
         getValue: function () {
             'use strict';
-            return this.sanitizeValue(this.element.find("input").val());
+            return this.sanitizeValue(this.element.find("input.input_in_place").val());
         },
 
         // When buttons are present, use a timer on the blur event to give precedence to clicks
@@ -660,6 +661,3 @@ jQuery.fn.best_in_place = function () {
 
     return this;
 };
-
-
-


### PR DESCRIPTION
Improves compatibility with Select2. Select2 will create its own
`input` field before the default `input` field used by `best_in_place`.
Thus the returned value will not be that of the `best_in_place`'s input.

This PR adds a selector class so the selector for the input value is
more deterministic.
Ref: Issue #510