### PR TITLE
Added ability to use different input types

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -209,6 +209,12 @@ BestInPlaceEditor.prototype = {
         if (self.formType === "select" || self.formType === "checkbox") {
             self.values = self.collection;
             self.collectionValue = self.element.data("bipValue") || self.collectionValue;
+        } else if (self.formType === "input") {
+            if (self.html_attrs != null && self.html_attrs["type"] != null) {
+                self.input_type  = self.html_attrs["type"];
+            } else {
+                self.input_type = "text";
+            }
         }
     },
 
@@ -371,7 +377,7 @@ BestInPlaceEditor.forms = {
                 .attr('action', 'javascript:void(0);')
                 .attr('style', 'display:inline');
             var input_elt = jQuery(document.createElement('input'))
-                .attr('type', 'text')
+                .attr('type', this.input_type)
                 .attr('name', this.attributeName)
                 .val(this.display_value);
 
@@ -386,15 +392,15 @@ BestInPlaceEditor.forms = {
             this.element.html(output);
             this.setHtmlAttributes();
 
-            this.element.find("input[type='text']")[0].select();
+            this.element.find("input[type='" + this.input_type + "']")[0].select();
             this.element.find("form").bind('submit', {editor: this}, BestInPlaceEditor.forms.input.submitHandler);
             if (this.cancelButton) {
                 this.element.find("input[type='button']").bind('click', {editor: this}, BestInPlaceEditor.forms.input.cancelButtonHandler);
             }
             if (!this.okButton) {
-                this.element.find("input[type='text']").bind('blur', {editor: this}, BestInPlaceEditor.forms.input.inputBlurHandler);
+                this.element.find("input[type='" + this.input_type + "']").bind('blur', {editor: this}, BestInPlaceEditor.forms.input.inputBlurHandler);
             }
-            this.element.find("input[type='text']").bind('keyup', {editor: this}, BestInPlaceEditor.forms.input.keyupHandler);
+            this.element.find("input[type='" + this.input_type + "']").bind('keyup', {editor: this}, BestInPlaceEditor.forms.input.keyupHandler);
             this.blurTimer = null;
             this.userClicked = false;
         },
@@ -407,6 +413,15 @@ BestInPlaceEditor.forms = {
         // When buttons are present, use a timer on the blur event to give precedence to clicks
         inputBlurHandler: function (event) {
             'use strict';
+            // Checking if input value is valid (native html5 validation)
+            // If browser doesn't supports html5 validation willValidate property will be 'undefined' and
+            // no check will be performed
+            var input = event.data.editor.element.find("input[type='" + event.data.editor.input_type + "']").get(0);
+            if (input.willValidate == true && !input.validity.valid) {
+                event.data.editor.abort();
+                return;
+            }
+
             if (event.data.editor.okButton) {
                 event.data.editor.blurTimer = setTimeout(function () {
                     if (!event.data.editor.userClicked) {

--- a/lib/best_in_place/test_helpers.rb
+++ b/lib/best_in_place/test_helpers.rb
@@ -44,7 +44,7 @@ module BestInPlace
       evaluate_script('!window.jQuery') || evaluate_script('jQuery.active').zero?
     end
 
-    def wait_until(max_execution_time_in_seconds = Capybara.default_wait_time)
+    def wait_until(max_execution_time_in_seconds = Capybara.default_max_wait_time)
       Timeout.timeout(max_execution_time_in_seconds) do
         loop do
           if yield

--- a/spec/internal/app/assets/stylesheets/application.css
+++ b/spec/internal/app/assets/stylesheets/application.css
@@ -1,0 +1,4 @@
+/*
+ *= require_self
+ *= require_tree .
+ */

--- a/spec/internal/app/views/layouts/application.html.erb
+++ b/spec/internal/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title>Best In Place TEST APP <%= Rails::VERSION::STRING %></title>
-  <%= stylesheet_link_tag "scaffold", "style", "jquery-ui-1.8.16.custom" %>
+  <%= stylesheet_link_tag "application" %>
   <%= javascript_include_tag "application" %>
   <%= csrf_meta_tag %>
 </head>


### PR DESCRIPTION
HTML5 introduced new handy input types like number, url, etc. and some basic validations.
I've tried to pass additional options to bip_helper in html_attrs params like
> best_in_place item, :arrived, html_attrs: {type: :number, min: 0, max: 100, step: 1, required: true}
but got javascript errors.

I've checked sources and see that input editor assumes that input always has 'text' type.
I've modified javascript to allow other input types.

now it works for me