### PR TITLE
Replace `delegate` with `on` for jQuery 3

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -668,7 +668,7 @@ jQuery.fn.best_in_place = function () {
         }
     }
 
-    jQuery(this.context).delegate(this.selector, 'click', function () {
+    jQuery(this.context).on(this.selector, 'click', function () {
         var el = jQuery(this);
         if (setBestInPlace(el)) {
             el.click();


### PR DESCRIPTION
`delegate` has been depreciated in jQuery 3 in favour of `on`