### PR TITLE
Fix bip_select by removing unsupported "Node#trigger" call

### DIFF
--- a/lib/best_in_place/test_helpers.rb
+++ b/lib/best_in_place/test_helpers.rb
@@ -4,7 +4,7 @@ module BestInPlace
 
     def bip_area(model, attr, new_value)
       id = BestInPlace::Utils.build_best_in_place_id model, attr
-      find("##{id}").trigger('click')
+      find("##{id}").click
       execute_script <<-JS
         $("##{id} form textarea").val('#{escape_javascript new_value.to_s}');
         $("##{id} form textarea").blur();
@@ -24,13 +24,13 @@ module BestInPlace
 
     def bip_bool(model, attr)
       id = BestInPlace::Utils.build_best_in_place_id model, attr
-      find("##{id}").trigger('click')
+      find("##{id}").click
       wait_for_ajax
     end
 
     def bip_select(model, attr, name)
       id = BestInPlace::Utils.build_best_in_place_id model, attr
-      find("##{id}").trigger('click')
+      find("##{id}").click
       find("##{id}").select(name)
       wait_for_ajax
     end


### PR DESCRIPTION
Fixes #587 

`bip_text` was already using `.click` which was coincidentally the only bip test helper I was using.  Changing the others to use .click instead of .trigger('click') and they work with Capybara (js: true).


The test in #587 now passes.
```
Finished in 8.68 seconds (files took 4.81 seconds to load)
1 example, 0 failures
```

Please let me know if there is any specific testing you'd like me to do.  This was a super quick fix.

Thanks.