### PR TITLE
support for ajaxDataType='script'

### DIFF
--- a/lib/assets/javascripts/best_in_place.js
+++ b/lib/assets/javascripts/best_in_place.js
@@ -107,7 +107,7 @@ BestInPlaceEditor.prototype = {
 
         editor.ajax({
             "type": this.requestMethod(),
-            "dataType": BestInPlaceEditor.defaults.ajaxDataType,
+            "dataType": this.ajaxDataType,
             "data": editor.requestData(),
             "success": function (data, status, xhr) {
                 editor.loadSuccessCallback(data, status, xhr);
@@ -180,6 +180,7 @@ BestInPlaceEditor.prototype = {
 
         // Load own attributes (overrides all others)
         self.url = self.element.data("bipUrl") || self.url || document.location.pathname;
+        self.ajaxDataType = self.element.data("bipAjaxDataType") || self.ajaxDataType || BestInPlaceEditor.defaults.ajaxDataType;
         self.collection = self.element.data("bipCollection") || self.collection;
         self.formType = self.element.data("bipType") || "input";
         self.objectName = self.element.data("bipObject") || self.objectName;
@@ -287,6 +288,11 @@ BestInPlaceEditor.prototype = {
 
     loadSuccessCallback: function (data, status, xhr) {
         'use strict';
+
+        if(this.ajaxDataType == 'script') {
+            return;
+        }
+
         data = jQuery.trim(data);
         //Update original content with current text.
         if (this.display_raw) {

--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -32,6 +32,8 @@ module BestInPlace
 
       pass_through_html_options(opts, options)
 
+      options[:data]['bip-ajax-data-type'] = opts[:ajax_data_type].presence
+
       options[:data]['bip-activator'] = opts[:activator].presence
 
       options[:data]['bip-html-attrs'] = opts[:html_attrs].to_json unless opts[:html_attrs].blank?
@@ -85,7 +87,7 @@ module BestInPlace
 
     def pass_through_html_options(opts, options)
       known_keys = [:id, :type, :nil, :classes, :collection, :data,
-                    :activator, :cancel_button, :cancel_button_class, :html_attrs, :inner_class, :nil,
+                    :activator, :ajax_data_type, :cancel_button, :cancel_button_class, :html_attrs, :inner_class, :nil,
                     :object_name, :ok_button, :ok_button_class, :display_as, :display_with, :path, :value,
                     :use_confirm, :confirm, :sanitize, :raw, :helper_options, :url, :place_holder, :class,
                     :as, :param, :container]

--- a/lib/best_in_place/test_helpers.rb
+++ b/lib/best_in_place/test_helpers.rb
@@ -4,7 +4,7 @@ module BestInPlace
 
     def bip_area(model, attr, new_value)
       id = BestInPlace::Utils.build_best_in_place_id model, attr
-      find("##{id}").trigger('click')
+      find("##{id}").click
       execute_script <<-JS
         $("##{id} form textarea").val('#{escape_javascript new_value.to_s}');
         $("##{id} form textarea").blur();
@@ -24,13 +24,13 @@ module BestInPlace
 
     def bip_bool(model, attr)
       id = BestInPlace::Utils.build_best_in_place_id model, attr
-      find("##{id}").trigger('click')
+      find("##{id}").click
       wait_for_ajax
     end
 
     def bip_select(model, attr, name)
       id = BestInPlace::Utils.build_best_in_place_id model, attr
-      find("##{id}").trigger('click')
+      find("##{id}").click
       find("##{id}").select(name)
       wait_for_ajax
     end


### PR DESCRIPTION
I wanted to use this gem with a server-generated JavaScript response (just loading the updated value via JSON was not enough). I needed to change two things to make it work:

1. The `dataType` of the ajax request must be `script` instead of `json`
2. The `loadSuccessCallback` should not try to parse responses which are not JSON

In case someone else is interested in this, I am willing to put a little more work into this to get this merged!
