### PR TITLE
Fix collection display

### DIFF
--- a/lib/best_in_place/helper.rb
+++ b/lib/best_in_place/helper.rb
@@ -22,7 +22,11 @@ module BestInPlace
         value = value.to_s
         collection = best_in_place_default_collection if collection.blank?
         collection = best_in_place_collection_builder(type, collection)
-        display_value = collection.flat_map{|a| a[0].to_s == value ? a[1] : nil }.compact[0]
+
+        unless opts[:display_as] || opts[:display_with]
+          display_value = collection.flat_map{|a| a[0].to_s == value ? a[1] : nil }.compact[0]
+        end
+
         collection = collection.to_json
         options[:data]['bip-collection'] = html_escape(collection)
       end


### PR DESCRIPTION
When generating the output for a collection or checkbox using `display_as`
or `display_with` the result is reformatted to match an option of the
collection. After editing and selecting a different option, the output
is rendered using the result from the display helper so the outputs differ
from what's initially rendered and when an edit is made. This change
only reformats the output to match a collection option when not using
`display_as` or `display_with` so the behavior is consistent.