### PR TITLE
Rails 6 - Deprecation Warning - moved includes out of initializer

### DIFF
--- a/lib/best_in_place.rb
+++ b/lib/best_in_place.rb
@@ -31,3 +31,6 @@ require 'best_in_place/helper'
 require 'best_in_place/railtie'
 require 'best_in_place/controller_extensions'
 require 'best_in_place/display_methods'
+
+ActionView::Base.send(:include, BestInPlace::Helper)
+ActionController::Base.send(:include, BestInPlace::ControllerExtensions)

--- a/lib/best_in_place/engine.rb
+++ b/lib/best_in_place/engine.rb
@@ -1,8 +1,5 @@
 module BestInPlace
   class Engine < Rails::Engine
-    initializer 'best_in_place' do
-      ActionView::Base.send(:include, BestInPlace::Helper)
-      ActionController::Base.send(:include, BestInPlace::ControllerExtensions)
-    end
+
   end
 end


### PR DESCRIPTION
The initializer was causing a deprecation warning about autoloading constants.  I resolved this by removing the initializer and moving the ActionView and ActionController includes.