### PR TITLE
fix rails 6 deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 #Changelog
 - unreleased
 
+- v.3.1.2 Tom Grushka
+  - Suppress Rails 6 deprecation warnings
+
 - v.3.1.1
   - Chore/improve readme
   - Upgrade PhantomJS version for travis and remove deprecation warning

--- a/lib/best_in_place/engine.rb
+++ b/lib/best_in_place/engine.rb
@@ -1,8 +1,11 @@
 module BestInPlace
   class Engine < Rails::Engine
     initializer 'best_in_place' do
-      ActionView::Base.send(:include, BestInPlace::Helper)
-      ActionController::Base.send(:include, BestInPlace::ControllerExtensions)
+      ActiveSupport.on_load(:action_controller) do
+        ActionView::Base.send(:include, BestInPlace::Helper)
+
+        ActionController::Base.send(:include, BestInPlace::ControllerExtensions)
+      end
     end
   end
 end

--- a/lib/best_in_place/railtie.rb
+++ b/lib/best_in_place/railtie.rb
@@ -4,7 +4,7 @@ require 'action_view/base'
 module BestInPlace
   class Railtie < ::Rails::Railtie #:nodoc:
     config.after_initialize do
-      BestInPlace::ViewHelpers = ActionView::Base.new
+      BestInPlace::ViewHelpers = ActionView::Base.respond_to?(:empty) ? ActionView::Base.empty : ActionView::Base.new
     end
   end
 end


### PR DESCRIPTION
This fixes a very annoying Rails 6 warning. Someone else did a PR on this but there were a lot more changes. This PR ONLY addresses the Rails 6 warning:

```
DEPRECATION WARNING: ActionView::Base instances should be constructed with a
lookup context, assignments, and a controller.
(called from <main> at /Users/tom/myapp/config/environment.rb:5)
```
